### PR TITLE
와이어프레임 제작- 홈 : 전체 필터뷰 연결

### DIFF
--- a/CatchMate/CatchMate.xcodeproj/project.pbxproj
+++ b/CatchMate/CatchMate.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		531786762C20494500ACEF6A /* HomeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531786752C20494500ACEF6A /* HomeRepository.swift */; };
 		531786782C20498800ACEF6A /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531786772C20498800ACEF6A /* Post.swift */; };
 		5317867B2C2077EC00ACEF6A /* NotiViewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5317867A2C2077EC00ACEF6A /* NotiViewTableViewCell.swift */; };
+		5317867D2C216CBE00ACEF6A /* NumberPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5317867C2C216CBE00ACEF6A /* NumberPickerViewController.swift */; };
 		536BDDAE2C189B230043B1DA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536BDDAD2C189B230043B1DA /* AppDelegate.swift */; };
 		536BDDB02C189B230043B1DA /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536BDDAF2C189B230043B1DA /* SceneDelegate.swift */; };
 		536BDDB22C189B230043B1DA /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536BDDB12C189B230043B1DA /* HomeViewController.swift */; };
@@ -101,6 +102,7 @@
 		531786752C20494500ACEF6A /* HomeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRepository.swift; sourceTree = "<group>"; };
 		531786772C20498800ACEF6A /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		5317867A2C2077EC00ACEF6A /* NotiViewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiViewTableViewCell.swift; sourceTree = "<group>"; };
+		5317867C2C216CBE00ACEF6A /* NumberPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberPickerViewController.swift; sourceTree = "<group>"; };
 		536BDDAA2C189B230043B1DA /* CatchMate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CatchMate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		536BDDAD2C189B230043B1DA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		536BDDAF2C189B230043B1DA /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -464,6 +466,7 @@
 				5317865F2C1EB24D00ACEF6A /* TeamFilterViewController.swift */,
 				531786612C1EE6C500ACEF6A /* TeamFilterTableViewCell.swift */,
 				5317866C2C200EDB00ACEF6A /* AllFilterViewController.swift */,
+				5317867C2C216CBE00ACEF6A /* NumberPickerViewController.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -653,6 +656,7 @@
 				536BDE122C1B51FD0043B1DA /* TabBarController.swift in Sources */,
 				536BDDB02C189B230043B1DA /* SceneDelegate.swift in Sources */,
 				531786642C1EF30F00ACEF6A /* Team.swift in Sources */,
+				5317867D2C216CBE00ACEF6A /* NumberPickerViewController.swift in Sources */,
 				5317867B2C2077EC00ACEF6A /* NotiViewTableViewCell.swift in Sources */,
 				531786662C1F014E00ACEF6A /* CMTextField.swift in Sources */,
 				5317866B2C200D6000ACEF6A /* BasePickerViewController.swift in Sources */,

--- a/CatchMate/CatchMate.xcodeproj/project.pbxproj
+++ b/CatchMate/CatchMate.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		531786782C20498800ACEF6A /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531786772C20498800ACEF6A /* Post.swift */; };
 		5317867B2C2077EC00ACEF6A /* NotiViewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5317867A2C2077EC00ACEF6A /* NotiViewTableViewCell.swift */; };
 		5317867D2C216CBE00ACEF6A /* NumberPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5317867C2C216CBE00ACEF6A /* NumberPickerViewController.swift */; };
+		5317867F2C217CB900ACEF6A /* TeamFilterCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5317867E2C217CB900ACEF6A /* TeamFilterCollectionViewCell.swift */; };
 		536BDDAE2C189B230043B1DA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536BDDAD2C189B230043B1DA /* AppDelegate.swift */; };
 		536BDDB02C189B230043B1DA /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536BDDAF2C189B230043B1DA /* SceneDelegate.swift */; };
 		536BDDB22C189B230043B1DA /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536BDDB12C189B230043B1DA /* HomeViewController.swift */; };
@@ -103,6 +104,7 @@
 		531786772C20498800ACEF6A /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		5317867A2C2077EC00ACEF6A /* NotiViewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiViewTableViewCell.swift; sourceTree = "<group>"; };
 		5317867C2C216CBE00ACEF6A /* NumberPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberPickerViewController.swift; sourceTree = "<group>"; };
+		5317867E2C217CB900ACEF6A /* TeamFilterCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamFilterCollectionViewCell.swift; sourceTree = "<group>"; };
 		536BDDAA2C189B230043B1DA /* CatchMate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CatchMate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		536BDDAD2C189B230043B1DA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		536BDDAF2C189B230043B1DA /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -467,6 +469,7 @@
 				531786612C1EE6C500ACEF6A /* TeamFilterTableViewCell.swift */,
 				5317866C2C200EDB00ACEF6A /* AllFilterViewController.swift */,
 				5317867C2C216CBE00ACEF6A /* NumberPickerViewController.swift */,
+				5317867E2C217CB900ACEF6A /* TeamFilterCollectionViewCell.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -657,6 +660,7 @@
 				536BDDB02C189B230043B1DA /* SceneDelegate.swift in Sources */,
 				531786642C1EF30F00ACEF6A /* Team.swift in Sources */,
 				5317867D2C216CBE00ACEF6A /* NumberPickerViewController.swift in Sources */,
+				5317867F2C217CB900ACEF6A /* TeamFilterCollectionViewCell.swift in Sources */,
 				5317867B2C2077EC00ACEF6A /* NotiViewTableViewCell.swift in Sources */,
 				531786662C1F014E00ACEF6A /* CMTextField.swift in Sources */,
 				5317866B2C200D6000ACEF6A /* BasePickerViewController.swift in Sources */,

--- a/CatchMate/CatchMate/DesignSystem/Components/CMPickerTextField.swift
+++ b/CatchMate/CatchMate/DesignSystem/Components/CMPickerTextField.swift
@@ -7,77 +7,106 @@
 
 import UIKit
 
-final class CMPickerTextField: UITextField {
-    private let padding = UIEdgeInsets(top: 17, left: 16, bottom: 17, right: 30)
+final class CMPickerTextField: UIView {
+    private let padding = UIEdgeInsets(top: 17, left: 16, bottom: 17, right: 16)
     
-    private let rightAccessoryView: UIView
+    private let rightAccessoryView: UIView?
     weak var parentViewController: UIViewController?
     var pickerViewController: BasePickerViewController?
     var customDetent: UISheetPresentationController.Detent?
     
-    init(rightAccessoryView: UIView) {
+    
+    private let textField: UITextField = {
+        let textField = UITextField()
+        textField.isEnabled = false
+        return textField
+    }()
+    
+    private let borderView: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = 8
+        view.backgroundColor = .white
+        view.layer.borderWidth = 1
+        view.layer.borderColor = UIColor.lightGray.cgColor
+        view.clipsToBounds = true
+        return view
+    }()
+    
+    init(rightAccessoryView: UIView, placeHolder: String = "") {
         self.rightAccessoryView = rightAccessoryView
+        self.textField.placeholder = placeHolder
         super.init(frame: .zero)
-        setup()
+        setupUI()
     }
     
+    @available (*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func setup() {
-        isEnabled = true
-        layer.cornerRadius = 8.0
-        layer.borderWidth = 1.0
-        layer.borderColor = UIColor.lightGray.cgColor
-        textColor = .black
-        backgroundColor = .white
-        font = UIFont.systemFont(ofSize: 16)
-        
-        attributedPlaceholder = NSAttributedString(string: placeholder ?? "", attributes: [NSAttributedString.Key.foregroundColor: UIColor.lightGray])
-        
-        rightView = rightAccessoryView
-        rightViewMode = .always
-        
-        inputView = UIView()
-        
-        addTarget(self, action: #selector(textFieldTapped), for: .editingDidBegin)
-    }
-    
-    override func textRect(forBounds bounds: CGRect) -> CGRect {
-        return bounds.inset(by: padding)
-    }
-    
-    override func editingRect(forBounds bounds: CGRect) -> CGRect {
-        return bounds.inset(by: padding)
-    }
-    
-    override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
-        return bounds.inset(by: padding)
-    }
     
     @objc private func textFieldTapped() {
-        layer.borderColor = UIColor.cmPrimaryColor.cgColor
+        borderView.layer.borderColor = UIColor.cmPrimaryColor.cgColor
         showPicker()
     }
     
     private func showPicker() {
         guard let pickerViewController = pickerViewController else { return }
+        
         pickerViewController.delegate = self
         pickerViewController.modalPresentationStyle = .pageSheet
-        if let customDetent = customDetent {
-            if let sheet = pickerViewController.sheetPresentationController {
-                sheet.detents = [customDetent]
-                sheet.prefersScrollingExpandsWhenScrolledToEdge = false
-            }
+        
+        if let sheet = pickerViewController.sheetPresentationController {
+            sheet.detents = customDetent != nil ? [customDetent!] : [.medium(), .large()]
+            sheet.prefersScrollingExpandsWhenScrolledToEdge = false
         }
+        
         parentViewController?.present(pickerViewController, animated: true, completion: nil)
     }
 }
 
+// MARK: - UI
+extension CMPickerTextField {
+    private func setupUI() {
+        addSubviews(views: [borderView, textField])
+        if let accessoryView = rightAccessoryView {
+            addSubview(accessoryView)
+        }
+
+        borderView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        textField.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(padding.top)
+            make.bottom.equalToSuperview().inset(padding.bottom)
+            make.leading.equalToSuperview().inset(padding.left)
+            if let rightAccessoryView = rightAccessoryView {
+                make.trailing.equalTo(rightAccessoryView.snp.leading).offset(-padding.right)
+            } else {
+                make.trailing.equalToSuperview().inset(padding.right)
+            }
+        }
+        
+        rightAccessoryView?.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().inset(padding.right)
+            make.centerY.equalToSuperview()
+            make.width.height.equalTo(24)
+        }
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(textFieldTapped))
+        addGestureRecognizer(tapGesture)
+    }
+}
+
+// MARK: - Base Picker View Delegate
 extension CMPickerTextField: BasePickerViewControllerDelegate {
+    func disable() {
+        borderView.layer.borderColor = UIColor.lightGray.cgColor
+    }
+    
     func didSelectItem(_ item: String) {
-        self.text = item
-        layer.borderColor = UIColor.lightGray.cgColor
+        textField.text = item
+        borderView.layer.borderColor = UIColor.lightGray.cgColor
     }
 }

--- a/CatchMate/CatchMate/Domain/Model/Team.swift
+++ b/CatchMate/CatchMate/Domain/Model/Team.swift
@@ -68,4 +68,6 @@ enum Team: String, CaseIterable {
             return UIImage(named: "giants_fill")
         }
     }
+    
+    static var allTeam: [Team] = Team.allCases
 }

--- a/CatchMate/CatchMate/Presentaions/View/Home/AllFilterViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/AllFilterViewController.swift
@@ -17,7 +17,7 @@ final class AllFilterViewController: UIViewController {
         return label
     }()
     
-    private let datePickerTextField = CMPickerTextField(rightAccessoryView: UIImageView(image: UIImage(systemName: "calendar")))
+    private let datePickerTextField = CMPickerTextField(rightAccessoryView: UIImageView(image: UIImage(systemName: "calendar")), placeHolder: "날짜 선택")
     
     private let teamSelectedLabel: UILabel = {
         let label = UILabel()
@@ -27,25 +27,62 @@ final class AllFilterViewController: UIViewController {
         return label
     }()
     
+    private let teamCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    
+    private let peopleNumLabel: UILabel = {
+        let label = UILabel()
+        label.text = "모집 인원 수"
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        label.textColor = .cmTextGray
+        return label
+    }()
+    
+    private let numberPickerTextField = CMPickerTextField(rightAccessoryView: {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16)
+        label.text = "명"
+        label.textColor = UIColor.lightGray
+        return label
+    }(), placeHolder: "최대 8")
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .cmBackgroundColor
         setupUI()
         setupPickerView()
+        setupToolBar()
+        teamCollectionView.backgroundColor = .red
+    }
+    
+    private func setupToolBar() {
+        let saveButton = UIBarButtonItem(title: "저장", style: .plain, target: self, action: #selector(clickSaveButton))
+        saveButton.tintColor = .cmPrimaryColor
+        navigationItem.rightBarButtonItem = saveButton
     }
     
     private func setupPickerView() {
-        datePickerTextField.placeholder = "날짜 선택"
+        // datePicker Setup
         datePickerTextField.parentViewController = self
         datePickerTextField.pickerViewController = DateFilterViewController()
         datePickerTextField.customDetent = BasePickerViewController.returnCustomDetent(height: Screen.height / 2.0 + 50.0, identifier: "DateFilter")
+        
+        // numberPicker Setup
+        numberPickerTextField.parentViewController = self
+        numberPickerTextField.pickerViewController = NumberPickerViewController()
+        numberPickerTextField.customDetent = BasePickerViewController.returnCustomDetent(height: Screen.height / 3.0 + 10.0, identifier: "NumberFilter")
+    }
+    
+    @objc
+    private func clickSaveButton(_ sender: UIBarButtonItem) {
+        print("저장")
+        navigationController?.popViewController(animated: true)
     }
 }
 
 // MARK: - UI
 extension AllFilterViewController {
     private func setupUI() {
-        view.addSubviews(views: [dateLabel, datePickerTextField, teamSelectedLabel])
+        view.addSubviews(views: [dateLabel, datePickerTextField, teamSelectedLabel, teamCollectionView, peopleNumLabel, numberPickerTextField])
         
         dateLabel.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).offset(16)
@@ -57,6 +94,19 @@ extension AllFilterViewController {
         }
         teamSelectedLabel.snp.makeConstraints { make in
             make.top.equalTo(datePickerTextField.snp.bottom).offset(40)
+            make.leading.trailing.equalTo(dateLabel)
+        }
+        teamCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(teamSelectedLabel.snp.bottom).offset(16)
+            make.leading.trailing.equalTo(dateLabel)
+            make.height.equalTo(270)
+        }
+        peopleNumLabel.snp.makeConstraints { make in
+            make.top.equalTo(teamCollectionView.snp.bottom).offset(40)
+            make.leading.trailing.equalTo(dateLabel)
+        }
+        numberPickerTextField.snp.makeConstraints { make in
+            make.top.equalTo(peopleNumLabel.snp.bottom).offset(16)
             make.leading.trailing.equalTo(dateLabel)
         }
     }

--- a/CatchMate/CatchMate/Presentaions/View/Home/AllFilterViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/AllFilterViewController.swift
@@ -27,7 +27,13 @@ final class AllFilterViewController: UIViewController {
         return label
     }()
     
-    private let teamCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    private let teamCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 10
+        layout.minimumInteritemSpacing = 10
+        return UICollectionView(frame: .zero, collectionViewLayout: layout)
+    }()
     
     private let peopleNumLabel: UILabel = {
         let label = UILabel()
@@ -50,14 +56,21 @@ final class AllFilterViewController: UIViewController {
         view.backgroundColor = .cmBackgroundColor
         setupUI()
         setupPickerView()
+        setupCollectionView()
         setupToolBar()
-        teamCollectionView.backgroundColor = .red
     }
     
     private func setupToolBar() {
         let saveButton = UIBarButtonItem(title: "저장", style: .plain, target: self, action: #selector(clickSaveButton))
         saveButton.tintColor = .cmPrimaryColor
         navigationItem.rightBarButtonItem = saveButton
+    }
+    
+    private func setupCollectionView() {
+        teamCollectionView.delegate = self
+        teamCollectionView.dataSource = self
+        teamCollectionView.register(TeamFilterCollectionViewCell.self, forCellWithReuseIdentifier: "TeamFilterCollectionViewCell")
+        teamCollectionView.backgroundColor = .clear
     }
     
     private func setupPickerView() {
@@ -76,6 +89,44 @@ final class AllFilterViewController: UIViewController {
     private func clickSaveButton(_ sender: UIBarButtonItem) {
         print("저장")
         navigationController?.popViewController(animated: true)
+    }
+}
+
+// MARK: - Team Collection View
+extension AllFilterViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return Team.allTeam.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "TeamFilterCollectionViewCell", for: indexPath) as? TeamFilterCollectionViewCell else {
+            return UICollectionViewCell()
+        }
+        cell.setupData(team: Team.allTeam[indexPath.row])
+        return cell
+    }
+
+    
+    // UICollectionViewDelegateFlowLayout
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        
+        guard let layout = collectionViewLayout as? UICollectionViewFlowLayout else {
+            return CGSize(width: 100, height: 100) 
+        }
+
+        let itemsPerRow: CGFloat = 4
+        let paddingSpace = layout.minimumInteritemSpacing * (itemsPerRow - 1)
+        let availableWidth = collectionView.frame.width - paddingSpace
+        let widthPerItem = availableWidth / itemsPerRow
+        return CGSize(width: widthPerItem, height: widthPerItem)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 10
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return 10
     }
 }
 

--- a/CatchMate/CatchMate/Presentaions/View/Home/DateFilterViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/DateFilterViewController.swift
@@ -28,6 +28,11 @@ final class DateFilterViewController: BasePickerViewController {
         setupButton()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        disable()
+    }
+    
     private func setupDatePicker() {
         datePicker.tintColor = .cmPrimaryColor
         datePicker.datePickerMode = .date

--- a/CatchMate/CatchMate/Presentaions/View/Home/NumberPickerViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/NumberPickerViewController.swift
@@ -1,0 +1,94 @@
+//
+//  NumberPickerView.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 6/18/24.
+//
+
+import UIKit
+
+final class NumberPickerViewController: BasePickerViewController {
+    private let picker: UIPickerView = UIPickerView()
+    private var selectedNum: Int = 1
+    private let numberArr: [Int] = [1,2,3,4,5,6,7,8]
+
+    private let saveButton: UIButton = {
+        let button = UIButton(configuration: .plain())
+        button.layer.cornerRadius = 4
+        button.backgroundColor = .cmPrimaryColor
+        button.setTitleColor(.white, for: .normal)
+        button.setTitle("저장", for: .normal)
+        button.tintColor = .clear
+        return button
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        setupUI()
+        setupPicker()
+        setupButton()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        disable()
+    }
+    
+    private func setupPicker() {
+        picker.delegate = self
+        picker.dataSource = self
+    }
+    
+    private func setupButton() {
+        saveButton.addTarget(self, action: #selector(clickSaveButton), for: .touchUpInside)
+    }
+    @objc
+    private func clickSaveButton(_ sender: UIButton) {
+        itemSelected(String(selectedNum))
+    }
+}
+
+// MARK: - Picker
+extension NumberPickerViewController: UIPickerViewDelegate, UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return numberArr.count
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        selectedNum = numberArr[row]
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return "\(numberArr[row])명"
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+        return 40.0
+    }
+}
+// MARK: - UI
+extension NumberPickerViewController {
+    private func setupUI() {
+        view.addSubviews(views: [picker, saveButton])
+        
+        picker.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(30)
+            make.leading.trailing.equalToSuperview().inset(12)
+        }
+
+        saveButton.snp.makeConstraints { make in
+            make.top.equalTo(picker.snp.bottom).offset(30)
+            make.leading.trailing.equalTo(picker)
+            make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-30)
+            make.height.equalTo(50)
+        }
+    }
+}
+
+
+

--- a/CatchMate/CatchMate/Presentaions/View/Home/TeamFilterCollectionViewCell.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/TeamFilterCollectionViewCell.swift
@@ -20,6 +20,8 @@ final class TeamFilterCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(clickImage))
+        addGestureRecognizer(tapGesture)
     }
     
     @available(*, unavailable)
@@ -31,8 +33,8 @@ final class TeamFilterCollectionViewCell: UICollectionViewCell {
         self.team = team
         teamLogoImage.image = team.getDefaultsImage
     }
-    
-    func clickImage() {
+    @objc
+    private func clickImage() {
         isSelect.toggle()
         if isSelect {
             teamLogoImage.image = team?.getFillImage

--- a/CatchMate/CatchMate/Presentaions/View/Home/TeamFilterCollectionViewCell.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/TeamFilterCollectionViewCell.swift
@@ -1,0 +1,51 @@
+//
+//  TeamFilterCollectionViewCell.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 6/18/24.
+//
+
+import UIKit
+import SnapKit
+
+final class TeamFilterCollectionViewCell: UICollectionViewCell {
+    private var team: Team?
+    private var isSelect: Bool = false
+    private let teamLogoImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .clear
+        imageView.contentMode = .scaleToFill
+        return imageView
+    }()
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setupData(team: Team) {
+        self.team = team
+        teamLogoImage.image = team.getDefaultsImage
+    }
+    
+    func clickImage() {
+        isSelect.toggle()
+        if isSelect {
+            teamLogoImage.image = team?.getFillImage
+        } else {
+            teamLogoImage.image = team?.getDefaultsImage
+        }
+    }
+    
+    private func setupUI() {
+        addSubview(teamLogoImage)
+        
+        teamLogoImage.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+}

--- a/CatchMate/CatchMate/Utilities/Base/BasePickerViewController.swift
+++ b/CatchMate/CatchMate/Utilities/Base/BasePickerViewController.swift
@@ -9,10 +9,17 @@ import UIKit
 
 protocol BasePickerViewControllerDelegate: AnyObject {
     func didSelectItem(_ item: String)
+    /// 시트가 선택 없이 내려서 사라질때 호출
+    func disable()
 }
 
 class BasePickerViewController: UIViewController {
     weak var delegate: BasePickerViewControllerDelegate?
+    
+    func disable() {
+        delegate?.disable()
+        dismiss(animated: true)
+    }
     
     func itemSelected(_ item: String) {
         delegate?.didSelectItem(item)
@@ -29,4 +36,5 @@ extension BasePickerViewController {
         return customDetent
     }
 }
+
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #4 

## 📝작업 내용
> 전체 필터 뷰 제작
> 재사용성을 높이기 위해 선택 시 픽커뷰가 나오는 텍스트 필드 디자인시스템으로 따로 분리

### 스크린샷 (선택)
<img src = "https://github.com/Dugout-Developers/CatchMate-iOS/assets/58802345/70d062ea-e63d-4e2f-bbcc-36bcf1176bbf" width = "300"></img>

