### PR TITLE
회원가입 로직 (기본 화면 전환, 네트워크X) 완료

### DIFF
--- a/CatchMate/CatchMate.xcodeproj/project.pbxproj
+++ b/CatchMate/CatchMate.xcodeproj/project.pbxproj
@@ -36,6 +36,10 @@
 		533A2B2C2C29485E00A59340 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A2B2B2C29485E00A59340 /* SignUpViewController.swift */; };
 		533A2B2E2C29B56200A59340 /* CMDefaultBorderedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A2B2D2C29B56100A59340 /* CMDefaultBorderedButton.swift */; };
 		533A2B302C2AC5C400A59340 /* InputFavoriteTeamViewContoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A2B2F2C2AC5C400A59340 /* InputFavoriteTeamViewContoller.swift */; };
+		533A2B322C2BE7E600A59340 /* CheerStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A2B312C2BE7E600A59340 /* CheerStyles.swift */; };
+		533A2B342C2BE98D00A59340 /* SignSelectedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A2B332C2BE98D00A59340 /* SignSelectedButton.swift */; };
+		533A2B362C2BEA3900A59340 /* InputCheerStyleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A2B352C2BEA3900A59340 /* InputCheerStyleViewController.swift */; };
+		533A2B382C2BFD4B00A59340 /* SignUpFinishedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A2B372C2BFD4B00A59340 /* SignUpFinishedViewController.swift */; };
 		536BDDAE2C189B230043B1DA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536BDDAD2C189B230043B1DA /* AppDelegate.swift */; };
 		536BDDB02C189B230043B1DA /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536BDDAF2C189B230043B1DA /* SceneDelegate.swift */; };
 		536BDDB22C189B230043B1DA /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536BDDB12C189B230043B1DA /* HomeViewController.swift */; };
@@ -122,6 +126,10 @@
 		533A2B2B2C29485E00A59340 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		533A2B2D2C29B56100A59340 /* CMDefaultBorderedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMDefaultBorderedButton.swift; sourceTree = "<group>"; };
 		533A2B2F2C2AC5C400A59340 /* InputFavoriteTeamViewContoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputFavoriteTeamViewContoller.swift; sourceTree = "<group>"; };
+		533A2B312C2BE7E600A59340 /* CheerStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheerStyles.swift; sourceTree = "<group>"; };
+		533A2B332C2BE98D00A59340 /* SignSelectedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignSelectedButton.swift; sourceTree = "<group>"; };
+		533A2B352C2BEA3900A59340 /* InputCheerStyleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputCheerStyleViewController.swift; sourceTree = "<group>"; };
+		533A2B372C2BFD4B00A59340 /* SignUpFinishedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpFinishedViewController.swift; sourceTree = "<group>"; };
 		536BDDAA2C189B230043B1DA /* CatchMate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CatchMate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		536BDDAD2C189B230043B1DA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		536BDDAF2C189B230043B1DA /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -249,6 +257,9 @@
 				533A2B262C28558600A59340 /* SignInViewController.swift */,
 				533A2B2B2C29485E00A59340 /* SignUpViewController.swift */,
 				533A2B2F2C2AC5C400A59340 /* InputFavoriteTeamViewContoller.swift */,
+				533A2B352C2BEA3900A59340 /* InputCheerStyleViewController.swift */,
+				533A2B372C2BFD4B00A59340 /* SignUpFinishedViewController.swift */,
+				533A2B332C2BE98D00A59340 /* SignSelectedButton.swift */,
 			);
 			path = Sign;
 			sourceTree = "<group>";
@@ -396,6 +407,7 @@
 				531786632C1EF30F00ACEF6A /* Team.swift */,
 				536BDDEB2C19720E0043B1DA /* User.swift */,
 				531786772C20498800ACEF6A /* Post.swift */,
+				533A2B312C2BE7E600A59340 /* CheerStyles.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -673,6 +685,7 @@
 			files = (
 				531786762C20494500ACEF6A /* HomeRepository.swift in Sources */,
 				536BDDB22C189B230043B1DA /* HomeViewController.swift in Sources */,
+				533A2B362C2BEA3900A59340 /* InputCheerStyleViewController.swift in Sources */,
 				536BDDF92C1972880043B1DA /* UserMapper.swift in Sources */,
 				531786782C20498800ACEF6A /* Post.swift in Sources */,
 				533A2B2C2C29485E00A59340 /* SignUpViewController.swift in Sources */,
@@ -690,9 +703,11 @@
 				5317866D2C200EDB00ACEF6A /* AllFilterViewController.swift in Sources */,
 				533A2B2A2C2859D600A59340 /* CMImageButton.swift in Sources */,
 				536BDE2F2C1B55240043B1DA /* NotiViewController.swift in Sources */,
+				533A2B382C2BFD4B00A59340 /* SignUpFinishedViewController.swift in Sources */,
 				536BDE362C1BEC870043B1DA /* ListCardViewTableViewCell.swift in Sources */,
 				536BDDFF2C1972D30043B1DA /* UserDataSource.swift in Sources */,
 				536BDDEC2C19720E0043B1DA /* User.swift in Sources */,
+				533A2B322C2BE7E600A59340 /* CheerStyles.swift in Sources */,
 				531786572C1C8F1900ACEF6A /* UIView+Extension.swift in Sources */,
 				536BDDE92C1971C70043B1DA /* SignReactor.swift in Sources */,
 				531786552C1C8E7800ACEF6A /* UIImage+Extension.swift in Sources */,
@@ -723,6 +738,7 @@
 				531786742C202F1B00ACEF6A /* NetworkService.swift in Sources */,
 				5317865B2C1C956400ACEF6A /* DateFilterViewController.swift in Sources */,
 				531786852C23261200ACEF6A /* SheetHeight.swift in Sources */,
+				533A2B342C2BE98D00A59340 /* SignSelectedButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CatchMate/CatchMate/Domain/Model/CheerStyles.swift
+++ b/CatchMate/CatchMate/Domain/Model/CheerStyles.swift
@@ -1,0 +1,53 @@
+//
+//  CheerStyles.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 6/26/24.
+//
+
+import UIKit
+
+enum CheerStyles: String, CaseIterable {
+    case director = "감독 스타일"
+    case mom = "어미새 스타일"
+    case eatLove = "먹보 스타일"
+    case cheerleader = "응원 단장 스타일"
+    case silent = "돌하르방 스타일"
+    case bodhisattva = "보살 스타일"
+    
+    var subInfo: String {
+        switch self {
+        case .director:
+            return "\"당근과 채찍\"\n감독 스타일"
+        case .mom:
+            return "\"무조건 애정과 박수\"\n어미새 스타일"
+        case .eatLove:
+            return "\"맛집이 어디라구요?\"\n먹보 스타일"
+        case .cheerleader:
+            return "\"이곳이 나의 무대\"\n응원 단장 스타일"
+        case .silent:
+            return "\"...\"\n돌하르방 스타일"
+        case .bodhisattva:
+            return "\"그럴 수 있지\"\n보살 스타일"
+        }
+    }
+    
+    var iconImage: UIImage? {
+        switch self {
+        case .director:
+            return UIImage(named: "EmptyDisable")
+        case .mom:
+            return UIImage(named: "EmptyDisable")
+        case .eatLove:
+            return UIImage(named: "EmptyDisable")
+        case .cheerleader:
+            return UIImage(named: "EmptyDisable")
+        case .silent:
+            return UIImage(named: "EmptyDisable")
+        case .bodhisattva:
+            return UIImage(named: "EmptyDisable")
+        }
+    }
+    
+    static let allCheerStyles: [CheerStyles] = CheerStyles.allCases
+}

--- a/CatchMate/CatchMate/Domain/Model/User.swift
+++ b/CatchMate/CatchMate/Domain/Model/User.swift
@@ -9,9 +9,11 @@ import UIKit
 
 struct User {
     var id: String = UUID().uuidString
-    var nickName: String
-    var age: UInt
-    var team: Team
+    let nickName: String
+    let age: UInt
+    let team: Team
+    let gener: Gender
+    let cheerStyle: CheerStyles?
 }
 
 enum Gender: String {

--- a/CatchMate/CatchMate/Presentaions/View/Sign/SignSelectedButton.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Sign/SignSelectedButton.swift
@@ -1,0 +1,83 @@
+//
+//  SignSelectedButton.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 6/26/24.
+//
+
+import UIKit
+import FlexLayout
+import PinLayout
+
+final class SignSelectedButton<T: CaseIterable>: UIView {
+    let item: T
+    var contentHeight: CGFloat?
+    var isSelected: Bool = false {
+        willSet {
+            updateFocus(newValue)
+        }
+    }
+    
+    private let containerView: UIView = {
+        let view = UIView()
+        view.layer.borderColor = UIColor.cmPrimaryColor.cgColor
+        view.clipsToBounds = true
+        return view
+    }()
+    
+    private let itemImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+    
+    private let label: UILabel = {
+        let label = UILabel()
+        label.textColor = .cmBodyTextColor
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.adjustsFontSizeToFitWidth = true
+        label.text = "팀명"
+        label.font = .systemFont(ofSize: 14, weight: .semibold)
+        return label
+    }()
+    
+    init(item: T) {
+        self.item = item
+        super.init(frame: .zero)
+        setupView(with: item)
+        setupUI()
+    }
+    
+    @available (*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    private func updateFocus(_ isSelected: Bool) {
+        if isSelected {
+            containerView.layer.borderWidth = 1
+            label.textColor = .cmPrimaryColor
+        } else {
+            label.textColor = .cmBodyTextColor
+            containerView.layer.borderWidth = 0
+        }
+    }
+    private func setupView(with item: T) {
+        if let team = item as? Team {
+            itemImage.image = team.getLogoImage
+            label.text = team.rawValue
+            contentHeight = 140
+        } else if let cheerStyle = item as? CheerStyles {
+            itemImage.image = cheerStyle.iconImage
+            label.text = cheerStyle.subInfo
+            contentHeight = 180
+        }
+    }
+    private func setupUI() {
+        addSubview(containerView)
+        containerView.flex.backgroundColor(.grayScale50).cornerRadius(8).direction(.column).justifyContent(.start).alignItems(.center).define { flex in
+            flex.addItem(itemImage).marginTop(15).marginBottom(5).marginHorizontal(7).shrink(1)
+            flex.addItem(label).marginBottom(30)
+        }.height(contentHeight)
+    }
+}

--- a/CatchMate/CatchMate/Presentaions/View/Sign/SignUpFinishedViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Sign/SignUpFinishedViewController.swift
@@ -1,0 +1,140 @@
+//
+//  SignUpFinishedViewController.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 6/26/24.
+//
+
+import UIKit
+import FlexLayout
+import PinLayout
+import ReactorKit
+import RxSwift
+import RxCocoa
+
+final class SignUpFinishedViewController: UIViewController , View {
+    var disposeBag = DisposeBag()
+    var reactor: SignReactor
+    
+    private let containerView = UIView()
+    
+    private let logoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "EmptyPrimary")
+        return imageView
+    }()
+    
+    private let finishedLabel: UILabel = {
+        let label = UILabel()
+        label.text = "회원가입 완료"
+        label.textColor = .cmHeadLineTextColor
+        label.font = .systemFont(ofSize: 24, weight: .semibold)
+        return label
+    }()
+    
+    private let subLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.numberOfLines = 2
+        label.text = "함께 할수록 더 재미있는 야구 직관\n캐치메이트에서 구해보세요!"
+        label.textColor = .cmNonImportantTextColor
+        label.font = .systemFont(ofSize: 14, weight: .semibold)
+        return label
+    }()
+    
+    private let nextButton: CMDefaultFilledButton = {
+        let button = CMDefaultFilledButton()
+        button.setTitle("다음", for: .normal)
+        return button
+    }()
+
+    
+    init(reactor: SignReactor) {
+        self.reactor = reactor
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+        setupUI()
+        bind(reactor: reactor)
+        hideNavigationBackButton()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        containerView.pin.all()
+        containerView.flex.layout()
+    }
+    
+    private func setupView() {
+        view.backgroundColor = .white
+        view.tappedDismissKeyboard()
+    }
+}
+
+
+// MARK: - bind
+extension SignUpFinishedViewController {
+    func bind(reactor: SignReactor) {
+        nextButton.rx.tap
+            .withUnretained(self)
+            .subscribe { _, _ in
+                (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootView(TabBarController(), animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+//        nextButton.rx.tap
+//            .map { Reactor.Action.signUpUser }
+//            .bind(to: reactor.action)
+//            .disposed(by: disposeBag)
+//
+//        
+//        
+//        reactor.state
+//            .map { $0.isSignUp }
+//            .distinctUntilChanged()
+//            .subscribe(onNext: { [weak self] isSignUp in
+//                if isSignUp == true {
+//                    self?.navigateToNextPage()
+//                } else if isSignUp == false {
+//                    self?.showErrorAlert()
+//                }
+//            })
+//            .disposed(by: disposeBag)
+
+    }
+    
+//    private func navigateToNextPage() {
+//            // Logic to navigate to the next page
+//            let nextViewController = UIViewController()
+//            navigationController?.pushViewController(nextViewController, animated: true)
+//        }
+//        
+//        private func showErrorAlert() {
+//            let alert = UIAlertController(title: "Error", message: "Sign up failed.", preferredStyle: .alert)
+//            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+//            present(alert, animated: true, completion: nil)
+//        }
+}
+
+// MARK: - UI
+extension SignUpFinishedViewController {
+    private func setupUI() {
+        view.addSubview(containerView)
+        containerView.flex.marginHorizontal(24).justifyContent(.start).alignItems(.center).define { flex in
+            flex.addItem().direction(.column).justifyContent(.center).alignItems(.center).define { flex in
+                flex.addItem(logoImageView).size(88).marginBottom(56)
+                flex.addItem(finishedLabel).marginBottom(24)
+                flex.addItem(subLabel)
+            }.grow(1)
+            flex.addItem(nextButton).width(100%).height(50).marginBottom(34)
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21 

## 📝작업 내용

> - 회원가입 화면 전환 및 기본 Validate 구현
> - TeamButton -> 응원 스타일까지 포용할 수 있는 Selected Button으로 확장

### 스크린샷 (선택)
![Simulator Screen Recording - iPhone 15 Pro - 2024-06-26 at 17 01 22](https://github.com/Dugout-Developers/CatchMate-iOS/assets/58802345/7e29208a-20b8-497f-825c-511165e8df1e)

![image](https://github.com/Dugout-Developers/CatchMate-iOS/assets/58802345/71d38b43-0486-492c-b6ce-cd08f06950c2)
