### PR TITLE
refactor: Error 핸들링 구조 개편

### DIFF
--- a/CatchMate/CatchMate.xcodeproj/project.pbxproj
+++ b/CatchMate/CatchMate.xcodeproj/project.pbxproj
@@ -206,8 +206,11 @@
 		537598062C46C0B0003BD8AE /* ApplyPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537598052C46C0B0003BD8AE /* ApplyPopupViewController.swift */; };
 		537598082C46C3D2003BD8AE /* DefaultsTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537598072C46C3D2003BD8AE /* DefaultsTextView.swift */; };
 		5375980C2C46DC45003BD8AE /* ChatRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5375980B2C46DC45003BD8AE /* ChatRoomViewController.swift */; };
+		5375B13D2D1A85F6000581B3 /* DomainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5375B13C2D1A85EA000581B3 /* DomainError.swift */; };
+		5375B13E2D1A85F6000581B3 /* DomainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5375B13C2D1A85EA000581B3 /* DomainError.swift */; };
 		5375B1472D1AEECE000581B3 /* ProfileImageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533B28F62C75BC2800BFE9F6 /* ProfileImageHelper.swift */; };
 		5375B1492D1AEEEE000581B3 /* ImageStringDecodingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5375B1482D1AEED7000581B3 /* ImageStringDecodingTest.swift */; };
+		5375B1572D228F25000581B3 /* BaseReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5375B1562D228F1F000581B3 /* BaseReactor.swift */; };
 		5378EA9B2C6487A600A2422C /* ReceiveMateListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5378EA9A2C6487A600A2422C /* ReceiveMateListCell.swift */; };
 		5378EA9D2C649B6900A2422C /* ReceiveMateListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5378EA9C2C649B6900A2422C /* ReceiveMateListViewController.swift */; };
 		5378EA9F2C649BBE00A2422C /* RecevieMateReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5378EA9E2C649BBE00A2422C /* RecevieMateReactor.swift */; };
@@ -337,7 +340,7 @@
 		53EECB012D1150C100775FD6 /* ApplyManageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EECB002D1150A700775FD6 /* ApplyManageUseCase.swift */; };
 		53EECB032D1151EE00775FD6 /* LoadAllReceiveAppliesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EECB022D1151CA00775FD6 /* LoadAllReceiveAppliesUseCase.swift */; };
 		53EECB052D11B07600775FD6 /* LoadReceivedCountUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EECB042D11B05A00775FD6 /* LoadReceivedCountUseCase.swift */; };
-		53EECB092D13E4B000775FD6 /* LoadNotificationIfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EECB082D13E4A400775FD6 /* LoadNotificationIfoUseCase.swift */; };
+		53EECB092D13E4B000775FD6 /* LoadNotificationInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EECB082D13E4A400775FD6 /* LoadNotificationInfoUseCase.swift */; };
 		53EECB0B2D13E4CF00775FD6 /* NotificationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EECB0A2D13E4CB00775FD6 /* NotificationInfo.swift */; };
 		53EECB0C2D13E4CF00775FD6 /* NotificationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EECB0A2D13E4CB00775FD6 /* NotificationInfo.swift */; };
 		53EECB0F2D14F00D00775FD6 /* SetNotificationDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EECB0E2D14F00100775FD6 /* SetNotificationDataSource.swift */; };
@@ -530,7 +533,9 @@
 		537598052C46C0B0003BD8AE /* ApplyPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplyPopupViewController.swift; sourceTree = "<group>"; };
 		537598072C46C3D2003BD8AE /* DefaultsTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultsTextView.swift; sourceTree = "<group>"; };
 		5375980B2C46DC45003BD8AE /* ChatRoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomViewController.swift; sourceTree = "<group>"; };
+		5375B13C2D1A85EA000581B3 /* DomainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainError.swift; sourceTree = "<group>"; };
 		5375B1482D1AEED7000581B3 /* ImageStringDecodingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStringDecodingTest.swift; sourceTree = "<group>"; };
+		5375B1562D228F1F000581B3 /* BaseReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseReactor.swift; sourceTree = "<group>"; };
 		5378EA9A2C6487A600A2422C /* ReceiveMateListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveMateListCell.swift; sourceTree = "<group>"; };
 		5378EA9C2C649B6900A2422C /* ReceiveMateListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveMateListViewController.swift; sourceTree = "<group>"; };
 		5378EA9E2C649BBE00A2422C /* RecevieMateReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecevieMateReactor.swift; sourceTree = "<group>"; };
@@ -642,7 +647,7 @@
 		53EECB002D1150A700775FD6 /* ApplyManageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplyManageUseCase.swift; sourceTree = "<group>"; };
 		53EECB022D1151CA00775FD6 /* LoadAllReceiveAppliesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadAllReceiveAppliesUseCase.swift; sourceTree = "<group>"; };
 		53EECB042D11B05A00775FD6 /* LoadReceivedCountUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadReceivedCountUseCase.swift; sourceTree = "<group>"; };
-		53EECB082D13E4A400775FD6 /* LoadNotificationIfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadNotificationIfoUseCase.swift; sourceTree = "<group>"; };
+		53EECB082D13E4A400775FD6 /* LoadNotificationInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadNotificationInfoUseCase.swift; sourceTree = "<group>"; };
 		53EECB0A2D13E4CB00775FD6 /* NotificationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationInfo.swift; sourceTree = "<group>"; };
 		53EECB0E2D14F00100775FD6 /* SetNotificationDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNotificationDataSource.swift; sourceTree = "<group>"; };
 		53EECB102D14F04B00775FD6 /* SetNotificationResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNotificationResponseDTO.swift; sourceTree = "<group>"; };
@@ -776,6 +781,7 @@
 		531786692C200D4700ACEF6A /* Base */ = {
 			isa = PBXGroup;
 			children = (
+				5375B1562D228F1F000581B3 /* BaseReactor.swift */,
 				53241F3B2C3C517600F468E1 /* GridSystem.swift */,
 				531786522C1C8BFB00ACEF6A /* BaseViewController.swift */,
 				5317866A2C200D6000ACEF6A /* BasePickerViewController.swift */,
@@ -1124,6 +1130,7 @@
 		536BDDED2C1972120043B1DA /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				5375B13C2D1A85EA000581B3 /* DomainError.swift */,
 				53EECB0A2D13E4CB00775FD6 /* NotificationInfo.swift */,
 				53EECAEF2D0B30A900775FD6 /* ProfileEdit.swift */,
 				53B8E2682C613127001D0ADF /* PresentationError.swift */,
@@ -1425,7 +1432,7 @@
 		53B8E23F2C5C7BF3001D0ADF /* User */ = {
 			isa = PBXGroup;
 			children = (
-				53EECB082D13E4A400775FD6 /* LoadNotificationIfoUseCase.swift */,
+				53EECB082D13E4A400775FD6 /* LoadNotificationInfoUseCase.swift */,
 				53EECAE52D0B2E7C00775FD6 /* ProfileEditUseCase.swift */,
 				5301E2B52C5BE6AF0078E910 /* LogoutUseCase.swift */,
 				53B8E23D2C5C7BEB001D0ADF /* LoadMyInfoUseCase.swift */,
@@ -1876,6 +1883,8 @@
 				53E5925C2C6D05DD0042E1D7 /* PostDetailUseCase.swift in Sources */,
 				53EECAE62D0B2E8300775FD6 /* ProfileEditUseCase.swift in Sources */,
 				531E4C252C6B549B0052E754 /* PostListLoadDataSource.swift in Sources */,
+				5375B1572D228F25000581B3 /* BaseReactor.swift in Sources */,
+				5375B13E2D1A85F6000581B3 /* DomainError.swift in Sources */,
 				538249132C3196AD0074B583 /* NaverLoginUseCase.swift in Sources */,
 				530DD6122C4F839600A7D6CE /* ServerLoginDataSource.swift in Sources */,
 				5317867D2C216CBE00ACEF6A /* NumberPickerViewController.swift in Sources */,
@@ -1917,7 +1926,7 @@
 				53B8E25D2C612245001D0ADF /* AddPostRepository.swift in Sources */,
 				53B3CE452C88AE1C00116BF7 /* ApplyList.swift in Sources */,
 				533B29232C7709C100BFE9F6 /* LoadFavoriteListRepository.swift in Sources */,
-				53EECB092D13E4B000775FD6 /* LoadNotificationIfoUseCase.swift in Sources */,
+				53EECB092D13E4B000775FD6 /* LoadNotificationInfoUseCase.swift in Sources */,
 				53ACBA272C7EB493004FAF00 /* UserInfoDTO.swift in Sources */,
 				53EECAF32D0BD17300775FD6 /* ProfileEditRepositoryImpl.swift in Sources */,
 				53ACBA5A2C85B7E6004FAF00 /* ApplyRepository.swift in Sources */,
@@ -1962,6 +1971,7 @@
 				53B3CE3F2C88577500116BF7 /* SNSLoginResponse.swift in Sources */,
 				53E7DBA42CA5664200DC058D /* DeletePostDataSource.swift in Sources */,
 				536BDDC52C189B240043B1DA /* CatchMateTests.swift in Sources */,
+				5375B13D2D1A85F6000581B3 /* DomainError.swift in Sources */,
 				53ACBA312C80B6C0004FAF00 /* PostListLoadDataSource.swift in Sources */,
 				533B29482C771F5E00BFE9F6 /* UIColor+Extension.swift in Sources */,
 				533B873B2C86E5970058B94B /* ApplyListDataSoueceTest.swift in Sources */,

--- a/CatchMate/CatchMate/Data/DTO/DataError.swift
+++ b/CatchMate/CatchMate/Data/DTO/DataError.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 // Token KeyChain 관련 Error
-enum TokenError: Error {
+enum TokenError: LocalizedError {
     case notFoundAccessToken
     case notFoundRefreshToken
     case failureSaveToken
@@ -42,7 +42,7 @@ enum TokenError: Error {
 }
 
 // 네트워크 에러
-enum NetworkError: Error {
+enum NetworkError: LocalizedError {
     case notFoundBaseURL
     case disconnected
     case slowConnection
@@ -100,7 +100,7 @@ enum NetworkError: Error {
 }
 
 // 매핑 에러
-enum MappingError: Error {
+enum MappingError: LocalizedError {
     ///DomainModel -> DTO
     case mappingFailed
     ///DTO -> DomainModel
@@ -125,7 +125,7 @@ enum MappingError: Error {
 }
 
 // 디코딩 에러
-enum CodableError: Error {
+enum CodableError: LocalizedError {
     case decodingFailed
     case encodingFailed
     case missingFields
@@ -153,10 +153,10 @@ enum CodableError: Error {
 }
 
 // SNS Login 관련 Error
-enum SNSLoginError: Error {
+enum SNSLoginError: LocalizedError {
     case authorizationFailed
     case EmptyValue
-    case loginServerError(code: Int, description: String)
+    case loginServerError(description: String)
 
 
     var statusCode: Int {
@@ -165,8 +165,8 @@ enum SNSLoginError: Error {
             return -5001
         case .EmptyValue:
             return -5002
-        case .loginServerError(let code, _):
-            return code
+        case .loginServerError:
+            return -5000
         }
     }
     
@@ -176,13 +176,13 @@ enum SNSLoginError: Error {
             return "권한 부여 실패 - 토큰 없음"
         case .EmptyValue:
             return "빈 응답값 전달"
-        case .loginServerError(_, let message):
+        case .loginServerError(let message):
             return "서버 에러: \(message)"
         }
     }
 }
 
-enum OtherError: Error {
+enum OtherError: LocalizedError {
     case invalidURL
     case notFoundSelf
     
@@ -200,7 +200,7 @@ enum OtherError: Error {
         case .invalidURL:
             return "URL 형식이 잘못되었습니다."
         case .notFoundSelf:
-            return "self 참조 "
+            return "self 참조 실패"
         }
     }
 }

--- a/CatchMate/CatchMate/Data/DataSources/Sign/KakaoDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/Sign/KakaoDataSource.swift
@@ -31,8 +31,8 @@ final class KakaoDataSourceImpl: NSObject, KakaoDataSource {
             if UserApi.isKakaoTalkLoginAvailable() {
                 UserApi.shared.loginWithKakaoTalk { [weak self] (oauthToken, error) in
                     if let error = error {
-                        LoggerService.shared.log("Kakao Login Error: \(error.statusCode) - \(error.localizedDescription)", level: .error)
-                        observer.onError(SNSLoginError.loginServerError(code: error.statusCode, description: error.localizedDescription))
+                        LoggerService.shared.log("Kakao Login Error: \(error.localizedDescription)", level: .error)
+                        observer.onError(SNSLoginError.loginServerError(description: error.localizedDescription))
                     } else {
                         guard let oauthToken = oauthToken else {
                             LoggerService.shared.log("KakaoLogin - oauthToken 없음", level: .error)
@@ -46,8 +46,8 @@ final class KakaoDataSourceImpl: NSObject, KakaoDataSource {
                 // 웹뷰
                 UserApi.shared.loginWithKakaoAccount { [weak self] (oauthToken, error) in
                     if let error = error {
-                        LoggerService.shared.log("Kakao Login Error: \(error.statusCode) - \(error.localizedDescription)", level: .error)
-                        observer.onError(SNSLoginError.loginServerError(code: error.statusCode, description: error.localizedDescription))
+                        LoggerService.shared.log("Kakao Login Error: \(error.localizedDescription)", level: .error)
+                        observer.onError(SNSLoginError.loginServerError(description: error.localizedDescription))
                     } else {
                         guard let oauthToken = oauthToken else {
                             LoggerService.shared.log("KakaoLogin - oauthToken 없음", level: .error)
@@ -67,7 +67,7 @@ final class KakaoDataSourceImpl: NSObject, KakaoDataSource {
         UserApi.shared.me(propertyKeys: ["properties.nickname", "properties.profile_image", "kakao_account.email"]) { user, error in
             if let error = error {
                 LoggerService.shared.log("KakaoLogin - \(error.localizedDescription)", level: .error)
-                observer.onError(SNSLoginError.loginServerError(code: error.statusCode, description: error.localizedDescription))
+                observer.onError(SNSLoginError.loginServerError(description: error.localizedDescription))
             } else {
                 guard let user = user, let id = user.id else {
                     LoggerService.shared.log("KakaoLogin Error - id를 찾을 수 없음", level: .error)

--- a/CatchMate/CatchMate/Data/DataSources/Sign/NaverLoginDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/Sign/NaverLoginDataSource.swift
@@ -132,7 +132,7 @@ final class NaverLoginDataSourceImpl: NSObject, NaverLoginDataSource, NaverThird
         print("Error: \(error.localizedDescription)")
         LoggerService.shared.log("NAVER API ERROR - \(error.localizedDescription)", level: .error)
         if let observer = naverLoginSubject {
-            observer.onError(SNSLoginError.loginServerError(code: error.statusCode, description: error.localizedDescription))
+            observer.onError(SNSLoginError.loginServerError(description: error.localizedDescription))
         }
     }
     

--- a/CatchMate/CatchMate/Data/DataSources/User/ProfileEditDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/User/ProfileEditDataSource.swift
@@ -20,49 +20,7 @@ final class ProfileEditDataSourceImpl: ProfileEditDataSource {
     init(tokenDataSource: TokenDataSource) {
         self.tokenDataSource = tokenDataSource
     }
-    
-//    func editProfile(editModel: ProfileEditRequestDTO) -> Observable<ProfileEditResponseDTO> {
-//        guard let token = tokenDataSource.getToken(for: .accessToken) else {
-//            return Observable.error(TokenError.notFoundAccessToken)
-//        }
-//        print(editModel)
-//        let headers: HTTPHeaders = [
-//            "AccessToken": token
-//        ]
-//        let parameters = APIService.shared.convertToDictionary(editModel)
-//
-//        return APIService.shared.requestAPI(type: .editProfile, parameters: parameters, headers: headers, encoding: JSONEncoding.default, dataType: ProfileEditResponseDTO.self)
-//            .map { dto in
-//                LoggerService.shared.debugLog("Profile Edit 성공: \(dto)")
-//                return dto
-//            }
-//            .catch { [weak self] error in
-//                guard let self else {
-//                    return Observable.error(OtherError.notFoundSelf)
-//                }
-//                if let error = error as? NetworkError, error.statusCode == 401 {
-//                    guard let refeshToken = tokenDataSource.getToken(for: .refreshToken) else {
-//                        return Observable.error(TokenError.notFoundRefreshToken)
-//                    }
-//                    return APIService.shared.refreshAccessToken(refreshToken: refeshToken)
-//                        .flatMap { token -> Observable<ProfileEditResponseDTO> in
-//                            let newHeaders: HTTPHeaders = [
-//                                "AccessToken": token
-//                            ]
-//                            LoggerService.shared.debugLog("토큰 재발급 후 재시도 \(token)")
-//                            return APIService.shared.requestAPI(type: .editProfile, parameters: parameters, headers: newHeaders, encoding: JSONEncoding.default, dataType: ProfileEditResponseDTO.self)
-//                                .map { dto in
-//                                    LoggerService.shared.debugLog("Profile Edit 성공: \(dto)")
-//                                    return dto
-//                                }
-//                        }
-//                        .catch { error in
-//                            return Observable.error(error)
-//                        }
-//                }
-//                return Observable.error(error)
-//            }
-//    }
+
     func editProfile(editModel: ProfileEditRequestDTO) -> Observable<ProfileEditResponseDTO> {
         guard let base = Bundle.main.baseURL else {
             LoggerService.shared.log("base 찾기 실패", level: .error)
@@ -94,11 +52,8 @@ final class ProfileEditDataSourceImpl: ProfileEditDataSource {
                 }
             }, to: url, method: .patch, headers: headers)
             .responseDecodable(of: ProfileEditResponseDTO.self) { response in
-                print("statusCode: \(response.response?.statusCode)")
-                print(response.response)
                 switch response.result {
                 case .success(let responseDTO):
-                    print("하")
                     observer.onNext(responseDTO) // 성공 시 데이터 반환
                     observer.onCompleted()
                 case .failure(let error):

--- a/CatchMate/CatchMate/DesignSystem/Base/BaseReactor.swift
+++ b/CatchMate/CatchMate/DesignSystem/Base/BaseReactor.swift
@@ -1,0 +1,6 @@
+//
+//  BaseReactor.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 12/30/24.
+//

--- a/CatchMate/CatchMate/Domain/Model/DomainError.swift
+++ b/CatchMate/CatchMate/Domain/Model/DomainError.swift
@@ -1,0 +1,44 @@
+//
+//  DomainError.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 12/24/24.
+//
+
+/// DomainError -> 맥락 + Error
+struct DomainError: Error {
+    let error: Error
+    let context: ErrorContext
+    let message: String?
+    
+    init(error: Error, context: ErrorContext, message: String? = nil) {
+        self.error = error
+        self.context = context
+        self.message = message
+    }
+}
+
+/// Presentation Error 발생 상황 맥락
+enum ErrorContext {
+    case action
+    case pageLoad
+    case tokenUnavailable
+}
+
+extension DomainError {
+    func toPresentationError() -> PresentationError {
+        let message = self.message
+        switch context {
+        case .action:
+            if let message {
+                return .showToastMessage(message: message)
+            } else {
+                return .showToastMessage(message: "오류가 발생했습니다. 다시 시도해주세요.")
+            }
+        case .pageLoad:
+            return .showErrorPage
+        case .tokenUnavailable:
+            return .unauthorized
+        }
+    }
+}

--- a/CatchMate/CatchMate/Domain/UseCases/Apply/AcceptApplyUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Apply/AcceptApplyUseCase.swift
@@ -22,5 +22,8 @@ final class AcceptApplyUseCaseImpl: AcceptApplyUseCase {
     
     func execute(enrollId: String) -> Observable<Bool> {
         return applyManagementRepository.acceptApply(enrollId: enrollId)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .action, message: "요청에 실패했습니다.").toPresentationError())
+            }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Apply/ApplyUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Apply/ApplyUseCase.swift
@@ -10,7 +10,7 @@ import RxSwift
 
 /// 신청하기
 protocol ApplyUseCase {
-    func excute(postId: String, addText: String?) -> Observable<Int>
+    func execute(postId: String, addText: String?) -> Observable<Int>
 }
 final class ApplyUseCaseImpl: ApplyUseCase {
     private let applyRepository: ApplyRepository
@@ -18,8 +18,11 @@ final class ApplyUseCaseImpl: ApplyUseCase {
         self.applyRepository = applyRepository
     }
     
-    func excute(postId: String, addText: String?) -> Observable<Int> {
+    func execute(postId: String, addText: String?) -> Observable<Int> {
         return applyRepository.applyPost(postId, addInfo: addText ?? "")
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .action, message: "요청에 실패했습니다.").toPresentationError())
+            }
     }
 }
 

--- a/CatchMate/CatchMate/Domain/UseCases/Apply/CancelApplyUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Apply/CancelApplyUseCase.swift
@@ -10,7 +10,7 @@ import RxSwift
 
 /// 신청 취소
 protocol CancelApplyUseCase {
-    func excute(enrollId: String) -> Observable<Void>
+    func execute(enrollId: String) -> Observable<Void>
 }
 final class CancelApplyUseCaseImpl: CancelApplyUseCase {
     private let applyRepository: ApplyRepository
@@ -18,7 +18,10 @@ final class CancelApplyUseCaseImpl: CancelApplyUseCase {
         self.applyRepository = applyRepository
     }
     
-    func excute(enrollId: String) -> Observable<Void> {
+    func execute(enrollId: String) -> Observable<Void> {
         return applyRepository.cancelApplyPost(enrollId: enrollId)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .action, message: "요청에 실패했습니다.").toPresentationError())
+            }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Apply/LoadAllReceiveAppliesUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Apply/LoadAllReceiveAppliesUseCase.swift
@@ -22,5 +22,8 @@ final class LoadAllReceiveAppliesUseCaseImpl: LoadAllReceiveAppliesUseCase {
     
     func execute() -> Observable<[RecivedApplies]> {
         return receivedAppliesRepository.loadReceivedAppliesAll()
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .pageLoad).toPresentationError())
+            }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Apply/LoadReceivedAppliesUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Apply/LoadReceivedAppliesUseCase.swift
@@ -22,5 +22,8 @@ final class LoadReceivedAppliesUseCaseImpl: LoadReceivedAppliesUseCase {
     
     func execute(boardId: Int) -> RxSwift.Observable<[RecivedApplyData]> {
         return receivedAppliesRepository.loadRecivedApplies(boardId: boardId)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .action, message: "요청에 실패했습니다.").toPresentationError())
+            }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Apply/LoadSendAppliesUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Apply/LoadSendAppliesUseCase.swift
@@ -20,5 +20,8 @@ final class LoadSendAppliesUseCaseImpl: LoadSendAppliesUseCase {
     }
     func execute() -> RxSwift.Observable<[ApplyList]> {
         return sendAppliesRepository.loadSendApplies()
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .pageLoad).toPresentationError())
+            }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Apply/RejectApplyUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Apply/RejectApplyUseCase.swift
@@ -22,5 +22,8 @@ final class RejectApplyUseCaseImpl: RejectApplyUseCase {
     
     func execute(enrollId: String) -> Observable<Bool> {
         return applyManagementRepository.rejectApply(enrollId: enrollId)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .action, message: "요청에 실패했습니다.").toPresentationError())
+            }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Notification/SetNotificationUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Notification/SetNotificationUseCase.swift
@@ -21,5 +21,8 @@ final class SetNotificationUseCaseImpl: SetNotificationUseCase {
     
     func execute(type: NotificationType, state: Bool) -> Observable<Bool> {
         return setNotificationRepository.setNotificationRepository(type: type, state: state)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .action, message: "요청에 실패했습니다.").toPresentationError())
+            }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Post/AddPostUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Post/AddPostUseCase.swift
@@ -21,13 +21,17 @@ final class AddPostUseCaseImpl: AddPostUseCase {
     }
     
     func addPost(_ post: RequestPost) -> Observable<Int> {
-        print("useCase:\(post)")
         return addPostRepository.addPost(post)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .action))
+            }
     }
     
     func editPost(_ post: RequestEditPost) -> Observable<Int> {
-        print("useCase:\(post)")
         return addPostRepository.editPost(post)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .action, message: "요청에 실패했습니다.").toPresentationError())
+            }
     }
 }
 

--- a/CatchMate/CatchMate/Domain/UseCases/Post/DeletePostUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Post/DeletePostUseCase.swift
@@ -10,7 +10,6 @@ import RxSwift
 
 protocol DeletePostUseCase {
     func deletePost(postId: Int) -> Observable<Void>
-    // 게시글 수정 필요
 }
 
 final class DeletePostUseCaseImpl: DeletePostUseCase {
@@ -21,5 +20,8 @@ final class DeletePostUseCaseImpl: DeletePostUseCase {
     
     func deletePost(postId: Int) -> RxSwift.Observable<Void> {
         return deleteRepository.deletePost(postId: postId)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .action, message: "게시물 삭제에 실패했습니다.").toPresentationError())
+            }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Post/LoadFavoriteListUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Post/LoadFavoriteListUseCase.swift
@@ -22,6 +22,9 @@ final class LoadFavoriteListUseCaseImpl: LoadFavoriteListUseCase {
     
     func execute() -> RxSwift.Observable<[SimplePost]> {
         return loadFavoriteListRepository.loadFavoriteList()
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .pageLoad).toPresentationError())
+            }
     }
     
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Post/PostDetailUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Post/PostDetailUseCase.swift
@@ -52,6 +52,9 @@ final class PostDetailUseCaseImpl: PostDetailUseCase {
                             }
                     }
             }
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .pageLoad).toPresentationError())
+            }
     }
 
     
@@ -65,6 +68,9 @@ final class PostDetailUseCaseImpl: PostDetailUseCase {
                 } else {
                     return Observable.just(nil)
                 }
+            }
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .pageLoad).toPresentationError())
             }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Post/PostListLoadUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Post/PostListLoadUseCase.swift
@@ -20,6 +20,9 @@ final class PostListLoadUseCaseImpl: PostListLoadUseCase {
     }
     func loadPostList(pageNum: Int, gudan: [String], gameDate: String, people: Int = 0) -> Observable<[SimplePost]> {
         return postListRepository.loadPostList(pageNum: pageNum, gudan: gudan, gameDate: gameDate, people: people)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .pageLoad, message: "요청에 실패했습니다.").toPresentationError())
+            }
     }
     
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Post/SetFavoriteUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Post/SetFavoriteUseCase.swift
@@ -21,5 +21,8 @@ final class SetFavoriteUseCaseImpl: SetFavoriteUseCase {
     
     func execute(_ state: Bool, _ boardId: String) -> Observable<Bool> {
         return setFavoriteRepository.setFavorite(state, boardId)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .action, message: "요청에 실패했습니다.").toPresentationError())
+            }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Post/UserPostLoadUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Post/UserPostLoadUseCase.swift
@@ -20,6 +20,9 @@ final class UserPostLoadUseCaseImpl: UserPostLoadUseCase {
     }
     func loadPostList(userId: Int, page: Int) -> Observable<[SimplePost]>{
         return userPostListRepository.loadPostList(userId: userId, page: page)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .pageLoad).toPresentationError())
+            }
     }
     
 }

--- a/CatchMate/CatchMate/Domain/UseCases/SNSLoginUseCase/AppleLoginUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/SNSLoginUseCase/AppleLoginUseCase.swift
@@ -30,5 +30,8 @@ final class AppleLoginUseCaseImpl: AppleLoginUseCase {
             let (snsModel, token) = arg1
             return usecase.serverRepository.login(snsModel: snsModel, token: token)
         }
+        .catch { error in
+            return Observable.error(DomainError(error: error, context: .action, message: "로그인에 실패했습니다.").toPresentationError())
+        }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/SNSLoginUseCase/KakaoLoginUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/SNSLoginUseCase/KakaoLoginUseCase.swift
@@ -30,5 +30,8 @@ final class KakaoLoginUseCaseImpl: KakaoLoginUseCase {
             let (snsModel, token) = arg1
             return usecase.serverRepository.login(snsModel: snsModel, token: token)
         }
+        .catch { error in
+            return Observable.error(DomainError(error: error, context: .action, message: "로그인에 실패했습니다.").toPresentationError())
+        }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/SNSLoginUseCase/NaverLoginUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/SNSLoginUseCase/NaverLoginUseCase.swift
@@ -30,6 +30,9 @@ final class NaverLoginUseCaseImpl: NaverLoginUseCase {
             let (snsModel, token) = arg1
             return usecase.serverRepository.login(snsModel: snsModel, token: token)
         }
+        .catch { error in
+            return Observable.error(DomainError(error: error, context: .action, message: "로그인에 실패했습니다.").toPresentationError())
+        }
     }
 }
 

--- a/CatchMate/CatchMate/Domain/UseCases/Sign/NicknameCheckUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Sign/NicknameCheckUseCase.swift
@@ -20,5 +20,8 @@ final class NicknameCheckUseCaseImpl: NicknameCheckUseCase {
     
     func execute(_ nickname: String) -> Observable<Bool> {
         return nicknameRepository.checkNickName(nickname)
+            .catch { error in
+                return Observable.just(false)
+            }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Sign/SetupUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Sign/SetupUseCase.swift
@@ -30,5 +30,8 @@ final class SetupUseCaseImpl: SetupUseCase {
             let ids = list.map{$0.id}
             return SetupResult(user: user, favoriteList: ids)
         }
+        .catch { error in
+            return Observable.error(DomainError(error: error, context: .tokenUnavailable).toPresentationError())
+        }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/Sign/SignUpUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Sign/SignUpUseCase.swift
@@ -13,14 +13,16 @@ protocol SignUpUseCase {
 }
 
 final class SignUpUseCaseImpl: SignUpUseCase {
-    func execute(_ model: LoginModel, signupInfo: SignUpModel) -> RxSwift.Observable<SignUpResponse> {
-        return repository.requestSignup(model, signupInfo: signupInfo)
-    }
-    
     private let repository: SignUpRepository
     
     init(repository: SignUpRepository) {
         self.repository = repository
     }
-
+    
+    func execute(_ model: LoginModel, signupInfo: SignUpModel) -> RxSwift.Observable<SignUpResponse> {
+        return repository.requestSignup(model, signupInfo: signupInfo)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .action, message: "회원가입에 실패했습니다.").toPresentationError())
+            }
+    }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/User/LoadMyInfoUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/User/LoadMyInfoUseCase.swift
@@ -11,7 +11,7 @@ import RxSwift
 protocol LoadMyInfoUseCase {
     func execute() -> Observable<User>
 }
-// loadCount -> 받은 신청 갯수 load 분리하고 상위 유즈케이스로 분리
+
 final class UserUseCaseImpl: LoadMyInfoUseCase {
     private let userRepository: UserRepository
     
@@ -21,6 +21,9 @@ final class UserUseCaseImpl: LoadMyInfoUseCase {
     
     func execute() -> Observable<User> {
         return userRepository.loadUser()
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .tokenUnavailable).toPresentationError())
+            }
     }
 }
 

--- a/CatchMate/CatchMate/Domain/UseCases/User/LoadNotificationInfoUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/User/LoadNotificationInfoUseCase.swift
@@ -8,11 +8,11 @@
 import UIKit
 import RxSwift
 
-protocol LoadNotificationIfoUseCase {
+protocol LoadNotificationInfoUseCase {
     func loadNotificationInfo() -> Observable<NotificationInfo>
 }
 
-final class LoadNotificationUseCaseImpl: LoadNotificationIfoUseCase {
+final class LoadNotificationUseCaseImpl: LoadNotificationInfoUseCase {
     private let userRepository: UserRepository
    
     init(userRepository: UserRepository) {
@@ -23,6 +23,9 @@ final class LoadNotificationUseCaseImpl: LoadNotificationIfoUseCase {
         return userRepository.loadUser()
             .map { user in
                 return NotificationInfo(user: user)
+            }
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .pageLoad).toPresentationError())
             }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/User/LoadReceivedCountUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/User/LoadReceivedCountUseCase.swift
@@ -18,7 +18,11 @@ final class LoadReceivedCountUseCaseImpl: LoadReceivedCountUseCase {
     init(loadCountRepository: ReceivedCountRepository) {
         self.loadCountRepository = loadCountRepository
     }
+    /// 해당 에러는 페이지 로드에 큰 영향이 없으므로 loadPage지만 에러 로그만 남기고 표시하지 않는걸로 대체
     func execute() -> Observable<Int> {
         return loadCountRepository.loadCount()
+            .catch { _ in
+                return Observable.just(0)
+            }
     }
 }

--- a/CatchMate/CatchMate/Domain/UseCases/User/ProfileEditUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/User/ProfileEditUseCase.swift
@@ -21,5 +21,9 @@ final class ProfileEditUseCaseImpl: ProfileEditUseCase {
     
     func editProfile(nickname: String, team: Team, style: CheerStyles?, image: UIImage?) -> Observable<Bool> {
         return repository.editProfile(nickname: nickname, team: team, style: style, image: image)
+            .catch { error in
+                return Observable.error(DomainError(error: error, context: .action, message: "요청에 실패했습니다.").toPresentationError())
+            }
+            
     }
 }

--- a/CatchMate/CatchMate/Presentaions/View/AddPost/AddViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/AddPost/AddViewController.swift
@@ -425,6 +425,13 @@ extension AddViewController {
             }
             .disposed(by: disposeBag)
 
+        reactor.state.map{$0.error}
+            .compactMap{$0}
+            .withUnretained(self)
+            .subscribe { vc, error in
+                vc.handleError(error)
+            }
+            .disposed(by: disposeBag)
     }
     
     // 작성 완료 후 호출되는 메소드

--- a/CatchMate/CatchMate/Presentaions/View/Favorite/FavoriteListViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Favorite/FavoriteListViewController.swift
@@ -121,6 +121,13 @@ final class FavoriteListViewController: BaseViewController ,View {
             }
             .disposed(by: disposeBag)
         
+        reactor.state.map{$0.error}
+            .compactMap{$0}
+            .withUnretained(self)
+            .subscribe { vc, error in
+                vc.handleError(error)
+            }
+            .disposed(by: disposeBag)
     }
     
     private func changeView(_ isEmpty: Bool) {

--- a/CatchMate/CatchMate/Presentaions/View/Home/HomeViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/HomeViewController.swift
@@ -194,6 +194,14 @@ extension HomeViewController {
                 vc.updateFilterContainerLayout()
             }
             .disposed(by: disposeBag)
+        
+        reactor.state.map{$0.error}
+            .compactMap{$0}
+            .withUnretained(self)
+            .subscribe { vc, error in
+                vc.handleError(error)
+            }
+            .disposed(by: disposeBag)
     
     }
     private func updateFilterContainerLayout() {

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/MyMenus/ReceiveMateListDetailViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/MyMenus/ReceiveMateListDetailViewController.swift
@@ -94,6 +94,14 @@ final class ReceiveMateListDetailViewController: BaseViewController, UICollectio
                 }
             }
             .disposed(by: disposeBag)
+        
+        reactor.state.map{$0.error}
+            .compactMap{$0}
+            .withUnretained(self)
+            .subscribe { vc, error in
+                vc.handleError(error)
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/MyMenus/ReceiveMateListViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/MyMenus/ReceiveMateListViewController.swift
@@ -87,6 +87,14 @@ extension ReceiveMateListViewController {
                 }
             }
             .disposed(by: disposeBag)
+        
+        reactor.state.map{$0.error}
+            .compactMap{$0}
+            .withUnretained(self)
+            .subscribe { vc, error in
+                vc.handleError(error)
+            }
+            .disposed(by: disposeBag)
 
     }
 }

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/MyMenus/SendMateListViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/MyMenus/SendMateListViewController.swift
@@ -79,5 +79,13 @@ extension SendMateListViewController {
                 vc.navigationController?.pushViewController(postDetailVC, animated: true)
             })
             .disposed(by: disposeBag)
+        
+        reactor.state.map{$0.error}
+            .compactMap{$0}
+            .withUnretained(self)
+            .subscribe { vc, error in
+                vc.handleError(error)
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/MyPageRoot/MyPageViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/MyPageRoot/MyPageViewController.swift
@@ -246,5 +246,13 @@ extension MyPageViewController {
                 vc.tableview.reloadData()
             }
             .disposed(by: disposeBag)
+        
+        reactor.state.map{$0.error}
+            .compactMap{$0}
+            .withUnretained(self)
+            .subscribe { vc, error in
+                vc.handleError(error)
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/MyPageRoot/OtherUserMyPageViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/MyPageRoot/OtherUserMyPageViewController.swift
@@ -179,6 +179,14 @@ extension OtherUserMyPageViewController {
             .bind { vc, offsetY in
                 vc.scrollSetupNavigation(offsetY)
             }.disposed(by: disposeBag)
+        
+        reactor.state.map{$0.error}
+            .compactMap{$0}
+            .withUnretained(self)
+            .subscribe { vc, error in
+                vc.handleError(error)
+            }
+            .disposed(by: disposeBag)
     }
     
     func scrollSetupNavigation(_ offsetY: CGFloat) {

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/ProfileEdit/ProfileEditViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/ProfileEdit/ProfileEditViewController.swift
@@ -210,6 +210,14 @@ extension ProfileEditViewController {
                 vc.profileImageView.image = image
             }
             .disposed(by: disposeBag)
+        
+        reactor.state.map{$0.error}
+            .compactMap{$0}
+            .withUnretained(self)
+            .subscribe { vc, error in
+                vc.handleError(error)
+            }
+            .disposed(by: disposeBag)
 
 // 닉네임 중복 검사 -> 나중에 연결
 //        nicknameTextField.rx.text.orEmpty

--- a/CatchMate/CatchMate/Presentaions/View/Sign/SignInViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Sign/SignInViewController.swift
@@ -108,14 +108,12 @@ extension SignInViewController {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        reactor.state
-            .map { $0.errorMessage }
-            .distinctUntilChanged()
-            .compactMap { $0 }
-            .subscribe(onNext: { errorMessage in
-                print("로그인 실패: \(errorMessage)")
-                // 에러 메시지 표시
-            })
+        reactor.state.map{$0.error}
+            .compactMap{$0}
+            .withUnretained(self)
+            .subscribe { vc, error in
+                vc.handleError(error)
+            }
             .disposed(by: disposeBag)
         
         appleLoginButton.rx.tap

--- a/CatchMate/CatchMate/Presentaions/View/Sign/SignUpViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Sign/SignUpViewController.swift
@@ -185,6 +185,7 @@ final class SignUpViewController: BaseViewController, View {
                 }
             })
             .disposed(by: disposeBag)
+        
     }
 }
 // MARK: - Button

--- a/CatchMate/CatchMate/Presentaions/View/TabBar/TabBarController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/TabBar/TabBarController.swift
@@ -41,7 +41,8 @@ final class TabBarController: UITabBarController, UITabBarControllerDelegate {
     private func settupTabbar() {
         let homeViewController = UINavigationController(rootViewController: HomeViewController(reactor: DIContainerService.shared.makeHomeReactor()))
         let favoriteViewController = isNonMember ? UINavigationController(rootViewController: NonMembersAccessViewController(title: "찜 목록")) : UINavigationController(rootViewController: FavoriteListViewController(reactor: DIContainerService.shared.makeFavoriteReactor()))
-        let addViewController = UINavigationController(rootViewController: BaseViewController()) // 네비게이션으로 연결할거기에 탭에는 빈 뷰컨트롤러 연결
+    
+        let addViewController = UINavigationController(rootViewController: UIViewController()) // 네비게이션으로 연결할거기에 탭에는 빈 뷰컨트롤러 연결
         let chatViewController = isNonMember ? UINavigationController(rootViewController: NonMembersAccessViewController(title: "채팅 목록")) : UINavigationController(rootViewController: ChatListViewController())
         let mypageViewController = isNonMember ? UINavigationController(rootViewController: EmptyMyPageViewController()) : UINavigationController(rootViewController: MyPageViewController(reactor: DIContainerService.shared.makeMypageReactor()))
         

--- a/CatchMate/CatchMate/Presentaions/ViewModel/AddReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/AddReactor.swift
@@ -98,11 +98,7 @@ final class AddReactor: Reactor {
                     return Mutation.setUser(simpleUser)
                 }
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
 
         case .changeGender(let gender):
@@ -160,11 +156,7 @@ final class AddReactor: Reactor {
                     return Mutation.savePost(id)
                 }
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         case .changeTitle(let title):
             return Observable.concat([
@@ -214,11 +206,7 @@ final class AddReactor: Reactor {
                     return Mutation.editPost(id)
                 }
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         }
     }

--- a/CatchMate/CatchMate/Presentaions/ViewModel/FavoriteReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/FavoriteReactor.swift
@@ -44,11 +44,7 @@ final class FavoriteReactor: Reactor {
                     return Mutation.setFavoritePost(list)
                 }
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         case .removeFavoritePost(let postId):
             return setFavoriteUsecase.execute(false, postId)
@@ -60,11 +56,7 @@ final class FavoriteReactor: Reactor {
                     return Mutation.setFavoritePost(currentList)
                 }
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         case .selectPost(let post):
             return Observable.just(Mutation.setSelectedPost(post))

--- a/CatchMate/CatchMate/Presentaions/ViewModel/HomeReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/HomeReactor.swift
@@ -86,9 +86,8 @@ final class HomeReactor: Reactor {
                 .flatMap({ reactor, _ in
                     return reactor.updateFiltersAndLoadPosts(date: nil, teams: nil, number: nil)
                 })
-                .catch { [weak self] error in
-                    guard let self = self else { return .empty()}
-                    return handlePresentationError(error)
+                .catch { error in
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
             
         case .loadNextPage:
@@ -104,9 +103,8 @@ final class HomeReactor: Reactor {
                     }
                     return .empty()
                 }
-                .catch { [weak self] error in
-                    guard let self = self else { return .empty() }
-                    return self.handlePresentationError(error)
+                .catch { error in
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         case .refreshPage:
             return Observable.concat([
@@ -165,9 +163,8 @@ final class HomeReactor: Reactor {
             .map { list in
                 Mutation.loadPost(list, append: false)
             }
-            .catch { [weak self] error in
-                guard let self = self else { return .empty()}
-                return handlePresentationError(error)
+            .catch { error in
+                return Observable.just(Mutation.setError(error.toPresentationError()))
             }
         
         return Observable.concat([
@@ -177,14 +174,5 @@ final class HomeReactor: Reactor {
             loadList,
             Observable.just(Mutation.incrementPage)
         ])
-    }
-    
-    // Helper Method: 에러 처리
-    private func handlePresentationError(_ error: Error) -> Observable<Mutation> {
-        if let presentationError = error as? PresentationError {
-            return Observable.just(Mutation.setError(presentationError))
-        } else {
-            return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-        }
     }
 }

--- a/CatchMate/CatchMate/Presentaions/ViewModel/MyPageReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/MyPageReactor.swift
@@ -18,13 +18,13 @@ final class MyPageReactor: Reactor {
         case setLoading(Bool)
         case setUser(User)
         case setCount(Int)
-        case setError(Error?)
+        case setError(PresentationError?)
         case logout(Bool)
     }
     struct State {
         var isLoading: Bool = false
         var user: User?
-        var error: Error?
+        var error: PresentationError?
         var count: Int = 0
         var logoutResult: Bool = false
     }
@@ -51,16 +51,16 @@ final class MyPageReactor: Reactor {
                 Observable.just(Mutation.setLoading(true)),
                 userUseCase.execute()
                     .map { Mutation.setUser($0) }
-                    .catch { .just(Mutation.setError($0)) },
+                    .catch { return Observable.just(Mutation.setError($0.toPresentationError())) },
                 loadReceivedCountUsecase.execute()
                     .map{ Mutation.setCount($0) }
-                    .catch { .just(Mutation.setError($0)) },
+                    .catch { return Observable.just(Mutation.setError($0.toPresentationError())) },
                 Observable.just(Mutation.setLoading(false))
             ])
         case .logout:
             return logoutUseCase.logout()
                 .map { Mutation.logout($0) }
-                .catch { .just(Mutation.setError($0))}
+                .catch { return Observable.just(Mutation.setError($0.toPresentationError())) }
         }
     }
     func reduce(state: State, mutation: Mutation) -> State {

--- a/CatchMate/CatchMate/Presentaions/ViewModel/NotificationSettingReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/NotificationSettingReactor.swift
@@ -33,10 +33,10 @@ final class NotificationSettingReactor: Reactor {
     }
     
     var initialState: State
-    private let notificationInfoUsecase: LoadNotificationIfoUseCase
+    private let notificationInfoUsecase: LoadNotificationInfoUseCase
     private let setNotificationUsecase: SetNotificationUseCase
     
-    init(notificationInfoUsecase: LoadNotificationIfoUseCase, setNotificationUsecase: SetNotificationUseCase) {
+    init(notificationInfoUsecase: LoadNotificationInfoUseCase, setNotificationUsecase: SetNotificationUseCase) {
         self.initialState = State()
         self.notificationInfoUsecase = notificationInfoUsecase
         self.setNotificationUsecase = setNotificationUsecase
@@ -50,11 +50,7 @@ final class NotificationSettingReactor: Reactor {
                     return Mutation.setNotificationInfo(info)
                 }
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         case .toggleSwitch((let type, let state)):
             print("\(type.rawValue) state changed to \(state)")

--- a/CatchMate/CatchMate/Presentaions/ViewModel/OtherUserpageReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/OtherUserpageReactor.swift
@@ -39,11 +39,7 @@ final class OtherUserpageReactor: Reactor {
                         return Mutation.setPost(list)
                     }
                     .catch { error in
-                        if let presentationError = error as? PresentationError {
-                            return Observable.just(Mutation.setError(presentationError))
-                        } else {
-                            return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                        }
+                        return Observable.just(Mutation.setError(error.toPresentationError()))
                     }
             } else {
                 return Observable.just(Mutation.setError(PresentationError.showErrorPage))

--- a/CatchMate/CatchMate/Presentaions/ViewModel/PostReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/PostReactor.swift
@@ -86,11 +86,7 @@ final class PostReactor: Reactor {
                     return Observable.concat(mutations)
                 }
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         case .changeApplyButtonState(let result):
             return Observable.just(Mutation.setApplyButtonState(result))
@@ -107,16 +103,12 @@ final class PostReactor: Reactor {
                     return Mutation.setError(PresentationError.showToastMessage(message: "찜하기 요청 실패. 다시 시도해주세요."))
                 }
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         case .setError(let error):
             return Observable.just(Mutation.setError(error))
         case .apply(let text):
-            return applyUsecase.excute(postId: postId, addText: text)
+            return applyUsecase.execute(postId: postId, addText: text)
                 .flatMap { id in
                     if id > 0 {
                         return Observable.concat([
@@ -128,24 +120,16 @@ final class PostReactor: Reactor {
                     }
                 }
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         case .cancelApply:
             if let enrollId = currentState.applyInfo?.enrollId {
-                return cancelApplyUsecase.excute(enrollId: enrollId)
+                return cancelApplyUsecase.execute(enrollId: enrollId)
                     .flatMap { _ in
                         return Observable.just(Mutation.setApplyButtonState(.none))
                     }
                     .catch { error in
-                        if let presentationError = error as? PresentationError {
-                            return Observable.just(Mutation.setError(presentationError))
-                        } else {
-                            return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                        }
+                        return Observable.just(Mutation.setError(error.toPresentationError()))
                     }
             } else {
                 return Observable.just(Mutation.setError(PresentationError.showToastMessage(message: "요청을 실패했습니다. 다시 시도해주세요.")))
@@ -157,11 +141,7 @@ final class PostReactor: Reactor {
                         return Observable.just(Mutation.deletePost)
                     }
                     .catch { error in
-                        if let presentationError = error as? PresentationError {
-                            return Observable.just(Mutation.setError(presentationError))
-                        } else {
-                            return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                        }
+                        return Observable.just(Mutation.setError(error.toPresentationError()))
                     }
             } else {
                 return Observable.just(Mutation.setError(PresentationError.showToastMessage(message: "삭제 실패. 다시 시도해주세요.")))

--- a/CatchMate/CatchMate/Presentaions/ViewModel/ProfileEditReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/ProfileEditReactor.swift
@@ -64,9 +64,6 @@ final class ProfileEditReactor: Reactor {
             let team = currentState.team
             let style = currentState.cheerStyle
             let image = currentState.profileImage
-//            guard let imageData = ProfileImageHelper.convertImageToBase64String(image: currentState.profileImage) else {
-//                return Observable.just(Mutation.setError(.showToastMessage(message: "프로필 변경에 실패했습니다. 다시 시도해주세요.")))
-//            }
             return profileEditUseCase.editProfile(nickname: nickname, team: team, style: style, image: image)
                 .map ({ state in
                     if state {
@@ -76,11 +73,7 @@ final class ProfileEditReactor: Reactor {
                     }
                 })
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(PresentationError.showToastMessage(message: "문제가 발생했습니다. 다시 시도해주세요.")))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         case .setError(let error):
             return Observable.just(Mutation.setError(error))

--- a/CatchMate/CatchMate/Presentaions/ViewModel/RecevieMateReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/RecevieMateReactor.swift
@@ -61,11 +61,7 @@ final class RecevieMateReactor: Reactor {
                         return Mutation.setSelectedPostApplies(result)
                     }
                     .catch { error in
-                        if let presentationError = error as? PresentationError {
-                            return Observable.just(Mutation.setError(presentationError))
-                        } else {
-                            return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                        }
+                        return Observable.just(Mutation.setError(error.toPresentationError()))
                     }
                 return Observable.concat([
                     Observable.just(Mutation.setReceiveAppliesAll(list)),
@@ -84,11 +80,7 @@ final class RecevieMateReactor: Reactor {
                     }
                 }
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         case .rejectApply(let enrollId):
             return applyManageUsecase.execute(type: .reject, enrollId: enrollId)
@@ -100,11 +92,7 @@ final class RecevieMateReactor: Reactor {
                     }
                 }
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         }
     }

--- a/CatchMate/CatchMate/Presentaions/ViewModel/SendMateReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/SendMateReactor.swift
@@ -37,11 +37,7 @@ final class SendMateReactor: Reactor {
                     return Observable.just(Mutation.setSendMatePost(posts))
                 }
                 .catch { error in
-                    if let presentationError = error as? PresentationError {
-                        return Observable.just(Mutation.setError(presentationError))
-                    } else {
-                        return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         }
     }

--- a/CatchMate/CatchMate/Presentaions/ViewModel/SignUpReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/SignUpReactor.swift
@@ -42,11 +42,7 @@ final class SignUpReactor: Reactor {
                     return Mutation.setSignUpResponse(response)
                 }
                 .catch { error in
-                    if let presentaionError = error as? PresentationError {
-                        return Observable.just(.setError(presentaionError))
-                    } else {
-                        return Observable.just(.setError(.showErrorPage))
-                    }
+                    return Observable.just(Mutation.setError(error.toPresentationError()))
                 }
         }
     }

--- a/CatchMate/CatchMate/Utilities/Extensions/Error+Extension.swift
+++ b/CatchMate/CatchMate/Utilities/Extensions/Error+Extension.swift
@@ -10,15 +10,23 @@ extension Error {
     static var errorType: String {
         return String(describing: self)
     }
-    
+
     var statusCode: Int {
-        if let localizedError = self as? LocalizedError, let statusCode = (localizedError as? CustomNSError)?.errorCode {
-            return statusCode
+        if let localizedError = self as? LocalizedError {
+            return localizedError.statusCode
         }
         return -9999 // 기본값으로 -9999를 반환
     }
 
     var errorDescription: String? {
         return (self as? LocalizedError)?.errorDescription ?? "An unexpected error occurred.: \(self.localizedDescription)"
+    }
+    
+    func toPresentationError() -> PresentationError {
+        if let presentationError = self as? PresentationError {
+            return presentationError
+        } else {
+            return PresentationError.showErrorPage
+        }
     }
 }

--- a/CatchMate/CatchMate/Utilities/Service/ErrorMapper.swift
+++ b/CatchMate/CatchMate/Utilities/Service/ErrorMapper.swift
@@ -85,19 +85,10 @@ final class ErrorMapper {
     
     private static func mapSNSLoginError(_ error: SNSLoginError) -> PresentationError {
         switch error {
-        case .authorizationFailed:
+        case .authorizationFailed, .loginServerError:
             return .showToastMessage(message: "로그인 요청에 실패했습니다. 다시 시도해주세요.")
         case .EmptyValue:
             return .showToastMessage(message: "로그인 정보를 가져오는데 실패했습니다. 지원팀에 문의해주세요.")
-        case .loginServerError(let code, _):
-            switch code {
-            case 400..<500:
-                return mapClientError(code)
-            case 500..<600:
-                return mapServerError(code)
-            default:
-                return .showErrorPage
-            }
         }
     }
     


### PR DESCRIPTION
## #️⃣연관된 이슈

> #77 

## 📝작업 내용

> Domain Error생성 후 프레젠테이션 에러와 연결
> 유즈케이스에서 catch Error에서 도메인에러로 변경
> 리액터 및 뷰컨트롤러 에러핸들링 코드 현재 필요한곳 모두 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
