### PR TITLE
Refactor: API Service 401에러 처리 함수로 DataSource 함수 모두 변경

### DIFF
--- a/CatchMate/CatchMate/Data/DTO/PostRequsetDTO.swift
+++ b/CatchMate/CatchMate/Data/DTO/PostRequsetDTO.swift
@@ -23,3 +23,26 @@ struct GameInfo: Codable {
     let gameStartDate: String?
     let location: String
 }
+
+
+extension PostRequsetDTO {
+    func encodingData() -> [String: Any] {
+        let parameters: [String: Any] = [
+            "title": self.title,
+            "content": self.content,
+            "maxPerson": self.maxPerson,
+            "cheerClubId": self.cheerClubId,
+            "preferredGender": self.preferredGender ?? "N",
+            "preferredAgeRange": self.preferredAgeRange,
+            "gameRequest": [
+                "homeClubId": self.gameRequest.homeClubId,
+                "awayClubId": self.gameRequest.awayClubId,
+                "gameStartDate": self.gameRequest.gameStartDate,
+                "location": self.gameRequest.location
+            ],
+            "isCompleted": self.isCompleted
+        ]
+        
+        return parameters
+    }
+}

--- a/CatchMate/CatchMate/Data/DataSources/APIService.swift
+++ b/CatchMate/CatchMate/Data/DataSources/APIService.swift
@@ -27,7 +27,7 @@ final class APIService {
         }
     }
     
-    func performRequest<T: Codable>(retry: Int = 0, addEndPoint: String? = nil, type: Endpoint, parameters: [String: Any]?, headers: HTTPHeaders? = nil, encoding: any ParameterEncoding = URLEncoding.default, dataType: T.Type, refreshToken: String? = nil) -> Observable<T> {
+    func performRequest<T: Codable>(retry: Int = 0, addEndPoint: String? = nil, type: Endpoint, parameters: [String: Any]?, headers: HTTPHeaders?, encoding: any ParameterEncoding, dataType: T.Type, refreshToken: String?) -> Observable<T> {
         if retry > maxRetryCount {
             LoggerService.shared.log("토큰 재발급 횟수 초과", level: .error)
             return Observable.error(NetworkError.tokenRefreshFailed)

--- a/CatchMate/CatchMate/Data/DataSources/Post/DeletePostDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/Post/DeletePostDataSource.swift
@@ -25,38 +25,21 @@ final class DeletePostDataSourceImpl: DeletePostDataSource {
         guard let token = tokenDataSource.getToken(for: .accessToken) else {
             return Observable.error(TokenError.notFoundAccessToken)
         }
+        guard let refreshToken = tokenDataSource.getToken(for: .refreshToken) else {
+            return Observable.error(TokenError.notFoundRefreshToken)
+        }
         let headers: HTTPHeaders = [
             "AccessToken": token
         ]
         LoggerService.shared.debugLog("DeletePostDataSourceImpl 토큰 확인: \(headers)")
         
-        return APIService.shared.requestAPI(addEndPoint: "\(postId)", type: .removePost, parameters: nil, headers: headers, encoding: JSONEncoding.default, dataType: DeletePostResponseDTO.self)
+        return APIService.shared.performRequest(addEndPoint: "\(postId)", type: .removePost, parameters: nil, headers: headers, encoding: URLEncoding.default, dataType: DeletePostResponseDTO.self, refreshToken: refreshToken)
             .map({ dto in
                 LoggerService.shared.debugLog("게시물 삭제 - 요청Id: \(postId) / 처리Id: \(dto.boardId)")
                 return ()
             })
-            .catch { [weak self] error in
-                guard let self = self else { return Observable.error(OtherError.notFoundSelf) }
-                if let error = error as? NetworkError, error.statusCode == 401 {
-                    guard let refeshToken = tokenDataSource.getToken(for: .refreshToken) else {
-                        return Observable.error(TokenError.notFoundRefreshToken)
-                    }
-                    return APIService.shared.refreshAccessToken(refreshToken: refeshToken)
-                        .flatMap { token in
-                            let headers: HTTPHeaders = [
-                                "AccessToken": token
-                            ]
-                            LoggerService.shared.debugLog("토큰 재발급 후 재시도 \(token)")
-                            return APIService.shared.requestAPI(addEndPoint: "\(postId)", type: .removePost, parameters: nil, headers: headers, encoding: JSONEncoding.default, dataType: DeletePostResponseDTO.self)
-                                .map { dto in
-                                    LoggerService.shared.debugLog("게시물 삭제 - 요청Id: \(postId) / 처리Id: \(dto.boardId)")
-                                    return ()
-                                }
-                        }
-                        .catch { error in
-                            return Observable.error(error)
-                        }
-                }
+            .catch { error in
+                LoggerService.shared.debugLog("\(postId)번 게시물 삭제 실패 - \(error)")
                 return Observable.error(error)
             }
     }

--- a/CatchMate/CatchMate/Data/DataSources/Post/EditPostDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/Post/EditPostDataSource.swift
@@ -20,59 +20,28 @@ final class EditPostDataSourceImpl: EditPostDataSource {
         self.tokenDataSource = tokenDataSource
     }
     func editPost(_ post: PostRequsetDTO, boardId: Int) -> Observable<Int> {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
         guard let token = tokenDataSource.getToken(for: .accessToken) else {
             return Observable.error(TokenError.notFoundAccessToken)
+        }
+        
+        guard let refreshToken = tokenDataSource.getToken(for: .refreshToken) else {
+            return Observable.error(TokenError.notFoundRefreshToken)
         }
         
         let headers: HTTPHeaders = [
             "AccessToken": token
         ]
         LoggerService.shared.log("토큰 확인: \(headers)")
-        
-        do {
-            let jsonData = try encoder.encode(post)
-            let jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: [])
-            print(jsonObject)
-            if let jsonDictionary = jsonObject as? [String: Any] {
-                LoggerService.shared.debugLog("parameters Encoding:\(jsonDictionary)")
-                return APIService.shared.requestAPI(addEndPoint: "\(boardId)", type: .editPost, parameters: jsonDictionary, headers: headers, encoding: JSONEncoding.default, dataType: AddPostResponseDTO.self)
-                    .map({ response in
-                        LoggerService.shared.debugLog("Post 수정 성공 - result: \(response)")
-                        return response.boardId
-                    })
-                    .catch { [weak self] error in
-                        guard let self = self else { return Observable.error(OtherError.notFoundSelf) }
-                        if let error = error as? NetworkError, error.statusCode == 401 {
-                            guard let refeshToken = tokenDataSource.getToken(for: .refreshToken) else {
-                                return Observable.error(TokenError.notFoundRefreshToken)
-                            }
-                            return APIService.shared.refreshAccessToken(refreshToken: refeshToken)
-                                .flatMap { newToken -> Observable<Int> in
-                                    return APIService.shared.requestAPI(type: .editPost, parameters: jsonDictionary, headers: headers, encoding: JSONEncoding.default, dataType: AddPostResponseDTO.self)
-                                        .map({ response in
-                                            LoggerService.shared.debugLog("Post 수정 성공 - result: \(response)")
-                                            return response.boardId
-                                        })
-                                }
-                                .catch { error in
-                                    return Observable.error(error)
-                                }
-                        }
-                        LoggerService.shared.log("Post DATASOURCE 저장 실패: ", level: .error)
-                        LoggerService.shared.log("JSON Data: \(String(data: jsonData, encoding: .utf8) ?? "") \n headers: \(headers)", level: .error)
-                        LoggerService.shared.log("\(error.localizedDescription)", level: .error)
-                        return Observable.error(error)
-                    }
-            } else {
-                LoggerService.shared.log("EditPostDataSource: PostRequset 인코딩 실패", level: .error)
-                return Observable.error(CodableError.encodingFailed)
+        let parameters = post.encodingData()
+        return APIService.shared.performRequest(addEndPoint: "\(boardId)", type: .editPost, parameters: parameters, headers: headers, encoding: JSONEncoding.default, dataType: AddPostResponseDTO.self, refreshToken: refreshToken)
+            .map({ response in
+                LoggerService.shared.debugLog("Post 수정 성공 - result: \(response)")
+                return response.boardId
+            })
+            .catch { error in
+                LoggerService.shared.debugLog("Post 수정 실패 - \(error)")
+                return Observable.error(error)
             }
-        } catch {
-            LoggerService.shared.log("EditPostDataSource: PostRequset 인코딩 실패", level: .error)
-            return Observable.error(CodableError.encodingFailed)
-        }
     }
 }
 

--- a/CatchMate/CatchMate/Data/DataSources/Post/LoadFavoriteListDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/Post/LoadFavoriteListDataSource.swift
@@ -39,7 +39,7 @@ final class LoadFavoriteListDataSourceImpl: LoadFavoriteListDataSource {
             }
             .catch { error in
                 LoggerService.shared.debugLog("Favorite List Load 실패 - \(error)")
-                Observable.error(error)
+                return Observable.error(error)
             }
     }
     

--- a/CatchMate/CatchMate/Data/DataSources/Post/LoadFavoriteListDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/Post/LoadFavoriteListDataSource.swift
@@ -25,39 +25,21 @@ final class LoadFavoriteListDataSourceImpl: LoadFavoriteListDataSource {
         guard let token = tokenDataSource.getToken(for: .accessToken) else {
             return Observable.error(TokenError.notFoundAccessToken)
         }
+        guard let refreshToken = tokenDataSource.getToken(for: .refreshToken) else {
+            return Observable.error(TokenError.notFoundRefreshToken)
+        }
         let headers: HTTPHeaders = [
             "AccessToken": token
         ]
         LoggerService.shared.log("토큰 확인: \(headers)")
-        
-        return APIService.shared.requestAPI(type: .loadFavorite, parameters: nil, headers: headers, dataType: PostListDTO.self)
+        return APIService.shared.performRequest(type: .loadFavorite, parameters: nil, headers: headers, encoding: URLEncoding.default, dataType: PostListDTO.self, refreshToken: refreshToken)
             .map { favoriteListDTO in
                 LoggerService.shared.debugLog("Favorite List Load 성공: \(favoriteListDTO)")
                 return favoriteListDTO.boardInfoList
             }
-            .catch { [weak self] error in
-                guard let self = self else { return Observable.error(OtherError.notFoundSelf) }
-                if let error = error as? NetworkError, error.statusCode == 401 {
-                    guard let refeshToken = tokenDataSource.getToken(for: .refreshToken) else {
-                        return Observable.error(TokenError.notFoundRefreshToken)
-                    }
-                    return APIService.shared.refreshAccessToken(refreshToken: refeshToken)
-                        .flatMap { token -> Observable<[PostListInfoDTO]> in
-                            let newHeaders: HTTPHeaders = [
-                                "AccessToken": token
-                            ]
-                            LoggerService.shared.debugLog("토큰 재발급 후 재시도 \(token)")
-                            return APIService.shared.requestAPI(type: .loadFavorite, parameters: nil, headers: newHeaders, encoding: URLEncoding.default, dataType: PostListDTO.self)
-                                .map { favoriteDTOList in
-                                    LoggerService.shared.debugLog("FavoriteList Load 성공: \(favoriteDTOList)")
-                                    return favoriteDTOList.boardInfoList
-                                }
-                                .catch { error in
-                                    return Observable.error(error)
-                                }
-                        }
-                }
-                return Observable.error(error)
+            .catch { error in
+                LoggerService.shared.debugLog("Favorite List Load 실패 - \(error)")
+                Observable.error(error)
             }
     }
     

--- a/CatchMate/CatchMate/Data/DataSources/Post/LoadTempPostDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/Post/LoadTempPostDataSource.swift
@@ -23,11 +23,14 @@ final class LoadTempPostDataSourceImpl: LoadTempPostDataSource {
         guard let token = tokenDataSource.getToken(for: .accessToken) else {
             return Observable.error(TokenError.notFoundAccessToken)
         }
+        guard let refreshToken = tokenDataSource.getToken(for: .refreshToken) else {
+            return Observable.error(TokenError.notFoundRefreshToken)
+        }
         let headers: HTTPHeaders = [
             "AccessToken": token
         ]
         
-        return APIService.shared.performRequest(type: .loadTempPost, parameters: nil, headers: headers, dataType: PostDTO.self)
+        return APIService.shared.performRequest(type: .loadTempPost, parameters: nil, headers: headers, encoding: URLEncoding.default, dataType: PostDTO.self, refreshToken: refreshToken)
             .map({ dto in
                 return dto
             })

--- a/CatchMate/CatchMate/Data/DataSources/Sign/SignUpDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/Sign/SignUpDataSource.swift
@@ -37,11 +37,10 @@ final class SignUpDataSourceImpl: SignUpDataSource {
         ]
          
         LoggerService.shared.debugLog("SignUp Parameters : \(parameters)")
-        return APIService.shared.requestAPI(type: .signUp, parameters: parameters, encoding: JSONEncoding.default, dataType: SignUpResponseDTO.self)
+        return APIService.shared.performRequest(type: .signUp, parameters: parameters, headers: nil, encoding: JSONEncoding.default, dataType: SignUpResponseDTO.self, refreshToken: nil)
             .withUnretained(self)
             .flatMap { ds, dto -> Observable<SignUpResponseDTO> in
                 LoggerService.shared.debugLog("회원가입 성공: \(dto)")
-                
                 // AccessToken 및 RefreshToken 저장
                 let accessTokenSaved = ds.tokenDataSource.saveToken(token: dto.accessToken, for: .accessToken)
                 let refreshTokenSaved = ds.tokenDataSource.saveToken(token: dto.refreshToken, for: .refreshToken)
@@ -51,13 +50,12 @@ final class SignUpDataSourceImpl: SignUpDataSource {
                     LoggerService.shared.debugLog("토큰 저장 실패")
                     return Observable.error(TokenError.failureTokenService)
                 }
-                
                 return Observable.just(dto)
             }
             .catch { error in
+                LoggerService.shared.debugLog("SignUp API 호출 실패 - \(error)")
                 return Observable.error(error)
             }
-        
     }
 }
 

--- a/CatchMate/CatchMate/Data/DataSources/User/LogoutDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/User/LogoutDataSource.swift
@@ -31,7 +31,7 @@ final class LogoutDataSourceImpl: LogoutDataSource {
             "RefreshToken": refeshToken
         ]
         
-        return APIService.shared.performRequest(type: .logout, parameters: nil, headers: headers, dataType: StateResponseDTO.self)
+        return APIService.shared.performRequest(type: .logout, parameters: nil, headers: headers, encoding: URLEncoding.default, dataType: StateResponseDTO.self, refreshToken: nil)
             .withUnretained(self)
             .map { ds, dto in
                 if dto.state {

--- a/CatchMate/CatchMate/Data/DataSources/User/UserDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/User/UserDataSource.swift
@@ -36,25 +36,13 @@ final class UserDataSourceImpl: UserDataSource {
         let headers: HTTPHeaders = [
             "AccessToken": token
         ]
-        return APIService.shared.requestAPI(type: .loadMyInfo, parameters: nil, headers: headers, dataType: UserDTO.self)
+        return APIService.shared.performRequest(type: .loadMyInfo, parameters: nil, headers: headers, encoding: URLEncoding.default, dataType: UserDTO.self, refreshToken: refeshToken)
             .map { user in
-                LoggerService.shared.log("UserDTO: \(user)")
+                LoggerService.shared.debugLog("UserDTO: \(user)")
                 return user
             }
             .catch { error in
-                if let error = error as? NetworkError, error.statusCode == 401 {
-                    return APIService.shared.refreshAccessToken(refreshToken: refeshToken)
-                        .flatMap { newToken -> Observable<UserDTO> in
-                            let newheaders: HTTPHeaders = [
-                                "AccessToken": newToken
-                            ]
-                            LoggerService.shared.debugLog("토큰 재발급 후 재시도 \(token)")
-                            return APIService.shared.requestAPI(type: .loadMyInfo, parameters: nil, headers: newheaders, dataType: UserDTO.self)
-                        }
-                        .catch { error in
-                            return Observable.error(error)
-                        }
-                }
+                LoggerService.shared.debugLog("내정보 load 실패 - \(error)")
                 return Observable.error(error)
             }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #86 

## 📝작업 내용

> - 기존 401 에러 데이터 소스에서 핸들링하던 함수 모두 서비스함수에서 처리하는 함수로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
