### PR TITLE
Fix: 고객센터 및 설정 관련 수정, 푸시알림 핸들링 등

### DIFF
--- a/CatchMate/CatchMate.xcodeproj/project.pbxproj
+++ b/CatchMate/CatchMate.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		537B8A9A2D6D67BA00C0499E /* AppVersionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B8A992D6D67B100C0499E /* AppVersionService.swift */; };
 		537B8A9C2D6D75E100C0499E /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 537B8A9B2D6D75E100C0499E /* FirebaseRemoteConfig */; };
 		537B8A9E2D6D75E100C0499E /* FirebaseRemoteConfigSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 537B8A9D2D6D75E100C0499E /* FirebaseRemoteConfigSwift */; };
+		537B8AA02D6D888400C0499E /* PhotoPermissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B8A9F2D6D887800C0499E /* PhotoPermissionService.swift */; };
 		53820CC22C8601120059A1F8 /* SendAppiesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53820CC12C8601120059A1F8 /* SendAppiesDataSource.swift */; };
 		5382490E2C2E79A90074B583 /* AppleLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5382490D2C2E79A90074B583 /* AppleLoginUseCase.swift */; };
 		538249102C3139C80074B583 /* AppleLoginUserDefaultsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5382490F2C3139C80074B583 /* AppleLoginUserDefaultsService.swift */; };
@@ -752,6 +753,7 @@
 		5378EA9C2C649B6900A2422C /* ReceiveMateListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveMateListViewController.swift; sourceTree = "<group>"; };
 		5378EA9E2C649BBE00A2422C /* RecevieMateReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecevieMateReactor.swift; sourceTree = "<group>"; };
 		537B8A992D6D67B100C0499E /* AppVersionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionService.swift; sourceTree = "<group>"; };
+		537B8A9F2D6D887800C0499E /* PhotoPermissionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPermissionService.swift; sourceTree = "<group>"; };
 		53820CC12C8601120059A1F8 /* SendAppiesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendAppiesDataSource.swift; sourceTree = "<group>"; };
 		5382490D2C2E79A90074B583 /* AppleLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginUseCase.swift; sourceTree = "<group>"; };
 		5382490F2C3139C80074B583 /* AppleLoginUserDefaultsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginUserDefaultsService.swift; sourceTree = "<group>"; };
@@ -1034,6 +1036,7 @@
 		531786722C202F0300ACEF6A /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				537B8A9F2D6D887800C0499E /* PhotoPermissionService.swift */,
 				537B8A992D6D67B100C0499E /* AppVersionService.swift */,
 				538E9AA02D6C0FF400A70A3D /* NotificationService.swift */,
 				53014A322D644242004C2EE0 /* OpenSourceLibraryService.swift */,
@@ -2255,6 +2258,7 @@
 				53C6DA002CE39DE000918718 /* ReceivedCountDataSource.swift in Sources */,
 				5378EA9F2C649BBE00A2422C /* RecevieMateReactor.swift in Sources */,
 				5320B04F2D5B017B00897EB7 /* DefualtTabelViewCell.swift in Sources */,
+				537B8AA02D6D888400C0499E /* PhotoPermissionService.swift in Sources */,
 				531786592C1C934A00ACEF6A /* UIViewController+Extension.swift in Sources */,
 				531288CB2C540764000C2FB1 /* FCMRepository.swift in Sources */,
 				5317865D2C1EAC4700ACEF6A /* Screen.swift in Sources */,

--- a/CatchMate/CatchMate.xcodeproj/project.pbxproj
+++ b/CatchMate/CatchMate.xcodeproj/project.pbxproj
@@ -46,6 +46,10 @@
 		53014A3D2D644BBC004C2EE0 /* InquiriesRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53014A3C2D644BB6004C2EE0 /* InquiriesRepositoryImpl.swift */; };
 		53014A3F2D644BC9004C2EE0 /* InquiriesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53014A3E2D644BC5004C2EE0 /* InquiriesRepository.swift */; };
 		53014A412D644BCF004C2EE0 /* InquiriesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53014A402D644BCC004C2EE0 /* InquiriesUseCase.swift */; };
+		53014A522D6B0000004C2EE0 /* LoadChatDetailDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53014A512D6AFFF4004C2EE0 /* LoadChatDetailDataSource.swift */; };
+		53014A542D6B0239004C2EE0 /* LoadChatDetailRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53014A532D6B022F004C2EE0 /* LoadChatDetailRepositoryImpl.swift */; };
+		53014A562D6B0246004C2EE0 /* LoadChatDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53014A552D6B0245004C2EE0 /* LoadChatDetailRepository.swift */; };
+		53014A582D6B0334004C2EE0 /* LoadChatDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53014A572D6B032D004C2EE0 /* LoadChatDetailUseCase.swift */; };
 		5301E2962C5B2BAE0078E910 /* LoggerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5301E2952C5B2BAE0078E910 /* LoggerService.swift */; };
 		5301E29D2C5B38B10078E910 /* Error+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5301E29C2C5B38B10078E910 /* Error+Extension.swift */; };
 		5301E2A12C5B5C280078E910 /* MyPageProfileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5301E2A02C5B5C280078E910 /* MyPageProfileCell.swift */; };
@@ -521,6 +525,10 @@
 		53014A3C2D644BB6004C2EE0 /* InquiriesRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiriesRepositoryImpl.swift; sourceTree = "<group>"; };
 		53014A3E2D644BC5004C2EE0 /* InquiriesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiriesRepository.swift; sourceTree = "<group>"; };
 		53014A402D644BCC004C2EE0 /* InquiriesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiriesUseCase.swift; sourceTree = "<group>"; };
+		53014A512D6AFFF4004C2EE0 /* LoadChatDetailDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadChatDetailDataSource.swift; sourceTree = "<group>"; };
+		53014A532D6B022F004C2EE0 /* LoadChatDetailRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadChatDetailRepositoryImpl.swift; sourceTree = "<group>"; };
+		53014A552D6B0245004C2EE0 /* LoadChatDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadChatDetailRepository.swift; sourceTree = "<group>"; };
+		53014A572D6B032D004C2EE0 /* LoadChatDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadChatDetailUseCase.swift; sourceTree = "<group>"; };
 		5301E2952C5B2BAE0078E910 /* LoggerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerService.swift; sourceTree = "<group>"; };
 		5301E29C2C5B38B10078E910 /* Error+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Extension.swift"; sourceTree = "<group>"; };
 		5301E2A02C5B5C280078E910 /* MyPageProfileCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageProfileCell.swift; sourceTree = "<group>"; };
@@ -1208,6 +1216,7 @@
 		535AA01E2D45FA7F007C7690 /* Chat */ = {
 			isa = PBXGroup;
 			children = (
+				53014A512D6AFFF4004C2EE0 /* LoadChatDetailDataSource.swift */,
 				530149E62D5ED416004C2EE0 /* ExportChatUserDataSource.swift */,
 				530149E42D5ED240004C2EE0 /* ExitChatRoomDataSource.swift */,
 				530149DA2D5E2878004C2EE0 /* UpdateChatImageDataSource.swift */,
@@ -1256,6 +1265,7 @@
 		535AA02E2D4602F4007C7690 /* Chat */ = {
 			isa = PBXGroup;
 			children = (
+				53014A532D6B022F004C2EE0 /* LoadChatDetailRepositoryImpl.swift */,
 				530149EE2D5ED6C6004C2EE0 /* ExitChatRoomRepositoryImpl.swift */,
 				530149EC2D5ED4D8004C2EE0 /* ExportChatUserRepositoryImpl.swift */,
 				530149DC2D5E2DA4004C2EE0 /* UpdateChatImageRepositoryImpl.swift */,
@@ -1269,6 +1279,7 @@
 		535AA0332D460333007C7690 /* Chat */ = {
 			isa = PBXGroup;
 			children = (
+				53014A552D6B0245004C2EE0 /* LoadChatDetailRepository.swift */,
 				530149EA2D5ED4BE004C2EE0 /* ExportChatUserRepository.swift */,
 				530149E82D5ED49A004C2EE0 /* ExitChatRoomRepository.swift */,
 				530149DE2D5E2DBD004C2EE0 /* UpdateChatImageRepository.swift */,
@@ -1282,6 +1293,7 @@
 		535AA0362D460484007C7690 /* Chat */ = {
 			isa = PBXGroup;
 			children = (
+				53014A572D6B032D004C2EE0 /* LoadChatDetailUseCase.swift */,
 				530149F22D5ED7E2004C2EE0 /* ExportChatUserUseCase.swift */,
 				530149F02D5ED768004C2EE0 /* ExitChatRoomUseCase.swift */,
 				530149E02D5E2E2F004C2EE0 /* UpdateChatImageUseCase.swift */,
@@ -2163,6 +2175,7 @@
 				53EECAEB2D0B2FFE00775FD6 /* ProfileEditRepository.swift in Sources */,
 				531288CD2C5408FF000C2FB1 /* LoginModel.swift in Sources */,
 				53577B492D55AEAA00769533 /* ChatSystemCell.swift in Sources */,
+				53014A582D6B0334004C2EE0 /* LoadChatDetailUseCase.swift in Sources */,
 				534E39EC2C63E771006D180E /* SendMateListCell.swift in Sources */,
 				535AA0382D4612D6007C7690 /* EmptyView.swift in Sources */,
 				53014A112D6374C9004C2EE0 /* BlockUserUseCase.swift in Sources */,
@@ -2279,6 +2292,7 @@
 				534E39D82C637FD3006D180E /* NotificationSettingViewController.swift in Sources */,
 				5375B1DB2D2E1977000581B3 /* DeleteNotificationRepository.swift in Sources */,
 				533A2B322C2BE7E600A59340 /* CheerStyles.swift in Sources */,
+				53014A542D6B0239004C2EE0 /* LoadChatDetailRepositoryImpl.swift in Sources */,
 				535AA0682D51BCEA007C7690 /* LoadChatMessageRepositoryImpl.swift in Sources */,
 				53B895CD2CA2579A00029130 /* UserPostLoadUseCase.swift in Sources */,
 				53B8E23E2C5C7BEB001D0ADF /* LoadMyInfoUseCase.swift in Sources */,
@@ -2383,6 +2397,7 @@
 				53C6DA022CE3A90F00918718 /* ReceivedCountRepositoryImpl.swift in Sources */,
 				5375B1A22D2CD381000581B3 /* NotificationList.swift in Sources */,
 				53F1E8C62C47A46400A962F3 /* Apply.swift in Sources */,
+				53014A522D6B0000004C2EE0 /* LoadChatDetailDataSource.swift in Sources */,
 				5301E2A32C5B6B8B0078E910 /* AuthManager.swift in Sources */,
 				535AA00E2D368097007C7690 /* SetAlarmnUseCase.swift in Sources */,
 				53014A0F2D637478004C2EE0 /* BlockManageRepository.swift in Sources */,
@@ -2406,6 +2421,7 @@
 				53ACBA372C81A91E004FAF00 /* CheerTeamPickerViewController.swift in Sources */,
 				535AA05B2D51B81D007C7690 /* ChatMessageDTO.swift in Sources */,
 				53368C942D30216200D129EE /* TempPostUseCase.swift in Sources */,
+				53014A562D6B0246004C2EE0 /* LoadChatDetailRepository.swift in Sources */,
 				53B8E2382C5C7BAA001D0ADF /* UserRepositoryImpl.swift in Sources */,
 				53EECAE82D0B2F8700775FD6 /* ProfileEditResponseDTO.swift in Sources */,
 				530149FA2D630723004C2EE0 /* ReportUserRepositoryImpl.swift in Sources */,

--- a/CatchMate/CatchMate.xcodeproj/project.pbxproj
+++ b/CatchMate/CatchMate.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		5378EA9B2C6487A600A2422C /* ReceiveMateListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5378EA9A2C6487A600A2422C /* ReceiveMateListCell.swift */; };
 		5378EA9D2C649B6900A2422C /* ReceiveMateListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5378EA9C2C649B6900A2422C /* ReceiveMateListViewController.swift */; };
 		5378EA9F2C649BBE00A2422C /* RecevieMateReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5378EA9E2C649BBE00A2422C /* RecevieMateReactor.swift */; };
+		537B8A9A2D6D67BA00C0499E /* AppVersionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B8A992D6D67B100C0499E /* AppVersionService.swift */; };
 		53820CC22C8601120059A1F8 /* SendAppiesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53820CC12C8601120059A1F8 /* SendAppiesDataSource.swift */; };
 		5382490E2C2E79A90074B583 /* AppleLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5382490D2C2E79A90074B583 /* AppleLoginUseCase.swift */; };
 		538249102C3139C80074B583 /* AppleLoginUserDefaultsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5382490F2C3139C80074B583 /* AppleLoginUserDefaultsService.swift */; };
@@ -748,6 +749,7 @@
 		5378EA9A2C6487A600A2422C /* ReceiveMateListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveMateListCell.swift; sourceTree = "<group>"; };
 		5378EA9C2C649B6900A2422C /* ReceiveMateListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveMateListViewController.swift; sourceTree = "<group>"; };
 		5378EA9E2C649BBE00A2422C /* RecevieMateReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecevieMateReactor.swift; sourceTree = "<group>"; };
+		537B8A992D6D67B100C0499E /* AppVersionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionService.swift; sourceTree = "<group>"; };
 		53820CC12C8601120059A1F8 /* SendAppiesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendAppiesDataSource.swift; sourceTree = "<group>"; };
 		5382490D2C2E79A90074B583 /* AppleLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginUseCase.swift; sourceTree = "<group>"; };
 		5382490F2C3139C80074B583 /* AppleLoginUserDefaultsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginUserDefaultsService.swift; sourceTree = "<group>"; };
@@ -1028,6 +1030,7 @@
 		531786722C202F0300ACEF6A /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				537B8A992D6D67B100C0499E /* AppVersionService.swift */,
 				538E9AA02D6C0FF400A70A3D /* NotificationService.swift */,
 				53014A322D644242004C2EE0 /* OpenSourceLibraryService.swift */,
 				5382490F2C3139C80074B583 /* AppleLoginUserDefaultsService.swift */,
@@ -2425,6 +2428,7 @@
 				53EECB052D11B07600775FD6 /* LoadReceivedCountUseCase.swift in Sources */,
 				536BDDB02C189B230043B1DA /* SceneDelegate.swift in Sources */,
 				5375B1A62D2CD43C000581B3 /* NotificationMapper.swift in Sources */,
+				537B8A9A2D6D67BA00C0499E /* AppVersionService.swift in Sources */,
 				535AA0112D368097007C7690 /* DeleteNotificationUseCase.swift in Sources */,
 				535AA0122D368097007C7690 /* LoadNotificationListUseCase.swift in Sources */,
 				53ACBA372C81A91E004FAF00 /* CheerTeamPickerViewController.swift in Sources */,
@@ -2742,7 +2746,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tori.CatchMate;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2944,7 +2948,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tori.CatchMate;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2982,7 +2986,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tori.CatchMate;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/CatchMate/CatchMate.xcodeproj/project.pbxproj
+++ b/CatchMate/CatchMate.xcodeproj/project.pbxproj
@@ -339,6 +339,9 @@
 		5383BE8D2C34D595008940F1 /* FontUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5383BE8C2C34D594008940F1 /* FontUtility.swift */; };
 		5383BE8F2C34DF27008940F1 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5383BE8E2C34DF27008940F1 /* Font.swift */; };
 		5383BE902C34ECD1008940F1 /* PretendardVariable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5383BE8A2C34D543008940F1 /* PretendardVariable.ttf */; };
+		538E9AA12D6C100300A70A3D /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538E9AA02D6C0FF400A70A3D /* NotificationService.swift */; };
+		538E9AA32D6C3C6600A70A3D /* Notification+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538E9AA22D6C3C5E00A70A3D /* Notification+Extension.swift */; };
+		538E9AA42D6C3C6600A70A3D /* Notification+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538E9AA22D6C3C5E00A70A3D /* Notification+Extension.swift */; };
 		538EB92F2C3FA27600ABA40E /* CMDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538EB92E2C3FA27600ABA40E /* CMDatePicker.swift */; };
 		539BD8632C74F0A5004720B8 /* DateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BE7ACE2C367008002FC64F /* DateHelper.swift */; };
 		53ACBA1D2C7D8E60004FAF00 /* CMActionMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53ACBA1C2C7D8E60004FAF00 /* CMActionMenu.swift */; };
@@ -753,6 +756,8 @@
 		5383BE8A2C34D543008940F1 /* PretendardVariable.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = PretendardVariable.ttf; sourceTree = "<group>"; };
 		5383BE8C2C34D594008940F1 /* FontUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontUtility.swift; sourceTree = "<group>"; };
 		5383BE8E2C34DF27008940F1 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
+		538E9AA02D6C0FF400A70A3D /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		538E9AA22D6C3C5E00A70A3D /* Notification+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Extension.swift"; sourceTree = "<group>"; };
 		538EB92E2C3FA27600ABA40E /* CMDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMDatePicker.swift; sourceTree = "<group>"; };
 		53ACBA1C2C7D8E60004FAF00 /* CMActionMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMActionMenu.swift; sourceTree = "<group>"; };
 		53ACBA1E2C7DDD36004FAF00 /* SetupResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupResult.swift; sourceTree = "<group>"; };
@@ -1023,6 +1028,7 @@
 		531786722C202F0300ACEF6A /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				538E9AA02D6C0FF400A70A3D /* NotificationService.swift */,
 				53014A322D644242004C2EE0 /* OpenSourceLibraryService.swift */,
 				5382490F2C3139C80074B583 /* AppleLoginUserDefaultsService.swift */,
 				5301E2952C5B2BAE0078E910 /* LoggerService.swift */,
@@ -1465,6 +1471,7 @@
 		536BDDE42C196FFD0043B1DA /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				538E9AA22D6C3C5E00A70A3D /* Notification+Extension.swift */,
 				536BDDE12C196F510043B1DA /* Bundle+Extension.swift */,
 				536BDE262C1B53150043B1DA /* UIColor+Extension.swift */,
 				531786542C1C8E7800ACEF6A /* UIImage+Extension.swift */,
@@ -2230,6 +2237,7 @@
 				53B8E2692C613127001D0ADF /* PresentationError.swift in Sources */,
 				53EECAF12D0B30B300775FD6 /* ProfileEdit.swift in Sources */,
 				5306F7BD2C9057D200292C6E /* LoadReceivedAppliesUseCase.swift in Sources */,
+				538E9AA42D6C3C6600A70A3D /* Notification+Extension.swift in Sources */,
 				531786602C1EB24D00ACEF6A /* TeamFilterViewController.swift in Sources */,
 				533B292B2C770F9F00BFE9F6 /* SetFavoriteRepositoryImpl.swift in Sources */,
 				531786822C21D3F700ACEF6A /* ChatListTableViewCell.swift in Sources */,
@@ -2370,6 +2378,7 @@
 				53EECB142D14F10200775FD6 /* SetAlarmRepository.swift in Sources */,
 				53EECB122D14F06300775FD6 /* SetNotificationResponseDTO.swift in Sources */,
 				535AA0242D45FB0D007C7690 /* LoadChatListDataSource.swift in Sources */,
+				538E9AA12D6C100300A70A3D /* NotificationService.swift in Sources */,
 				530149F12D5ED771004C2EE0 /* ExitChatRoomUseCase.swift in Sources */,
 				531786682C20048B00ACEF6A /* CMPickerTextField.swift in Sources */,
 				531786532C1C8BFB00ACEF6A /* BaseViewController.swift in Sources */,
@@ -2552,6 +2561,7 @@
 				535AA0582D51A7F7007C7690 /* SenderInfo.swift in Sources */,
 				53B3CE3F2C88577500116BF7 /* SNSLoginResponse.swift in Sources */,
 				5375B1A32D2CD381000581B3 /* NotificationList.swift in Sources */,
+				538E9AA32D6C3C6600A70A3D /* Notification+Extension.swift in Sources */,
 				53E7DBA42CA5664200DC058D /* DeletePostDataSource.swift in Sources */,
 				53014A022D631703004C2EE0 /* BlockUserInfoDTO.swift in Sources */,
 				53368C8D2D301CD900D129EE /* TempPostRequest.swift in Sources */,

--- a/CatchMate/CatchMate.xcodeproj/project.pbxproj
+++ b/CatchMate/CatchMate.xcodeproj/project.pbxproj
@@ -332,6 +332,8 @@
 		5378EA9D2C649B6900A2422C /* ReceiveMateListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5378EA9C2C649B6900A2422C /* ReceiveMateListViewController.swift */; };
 		5378EA9F2C649BBE00A2422C /* RecevieMateReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5378EA9E2C649BBE00A2422C /* RecevieMateReactor.swift */; };
 		537B8A9A2D6D67BA00C0499E /* AppVersionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B8A992D6D67B100C0499E /* AppVersionService.swift */; };
+		537B8A9C2D6D75E100C0499E /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 537B8A9B2D6D75E100C0499E /* FirebaseRemoteConfig */; };
+		537B8A9E2D6D75E100C0499E /* FirebaseRemoteConfigSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 537B8A9D2D6D75E100C0499E /* FirebaseRemoteConfigSwift */; };
 		53820CC22C8601120059A1F8 /* SendAppiesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53820CC12C8601120059A1F8 /* SendAppiesDataSource.swift */; };
 		5382490E2C2E79A90074B583 /* AppleLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5382490D2C2E79A90074B583 /* AppleLoginUseCase.swift */; };
 		538249102C3139C80074B583 /* AppleLoginUserDefaultsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5382490F2C3139C80074B583 /* AppleLoginUserDefaultsService.swift */; };
@@ -885,7 +887,9 @@
 				53368C882D2F9EED00D129EE /* NaverThirdPartyLogin in Frameworks */,
 				536BDE192C1B52510043B1DA /* SnapKit in Frameworks */,
 				536BDE152C1B52510043B1DA /* PinLayout in Frameworks */,
+				537B8A9C2D6D75E100C0499E /* FirebaseRemoteConfig in Frameworks */,
 				536BDE232C1B52510043B1DA /* RxAlamofire in Frameworks */,
+				537B8A9E2D6D75E100C0499E /* FirebaseRemoteConfigSwift in Frameworks */,
 				536BDE1B2C1B52510043B1DA /* RxCocoa in Frameworks */,
 				536BDE172C1B52510043B1DA /* FlexLayout in Frameworks */,
 				530DD6192C4F88C600A7D6CE /* FirebaseMessaging in Frameworks */,
@@ -2018,6 +2022,8 @@
 				535AA03B2D4667E3007C7690 /* Starscream */,
 				53577B352D5303D300769533 /* FirebaseAnalyticsWithoutAdIdSupport */,
 				53577B372D5303D300769533 /* FirebaseCrashlytics */,
+				537B8A9B2D6D75E100C0499E /* FirebaseRemoteConfig */,
+				537B8A9D2D6D75E100C0499E /* FirebaseRemoteConfigSwift */,
 			);
 			productName = CatchMate;
 			productReference = 536BDDAA2C189B230043B1DA /* CatchMate.app */;
@@ -3292,6 +3298,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 536BDE0F2C1B51440043B1DA /* XCRemoteSwiftPackageReference "RxAlamofire" */;
 			productName = RxAlamofire;
+		};
+		537B8A9B2D6D75E100C0499E /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 530DD6172C4F88B000A7D6CE /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
+		};
+		537B8A9D2D6D75E100C0499E /* FirebaseRemoteConfigSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 530DD6172C4F88B000A7D6CE /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfigSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/CatchMate/CatchMate/APP/AppDelegate.swift
+++ b/CatchMate/CatchMate/APP/AppDelegate.swift
@@ -12,13 +12,15 @@ import Firebase
 import FirebaseMessaging
 import UserNotifications
 import FirebaseAnalytics
+import RxSwift
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, MessagingDelegate {
     let gcmMessageIDKey = "gcm.message_id"
+    private let disposeBag = DisposeBag()
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-
+        
         FirebaseApp.configure()
 #if DEBUG
         Analytics.setAnalyticsCollectionEnabled(false) // 디버그 모드에서 비활성화
@@ -38,7 +40,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         UIApplication.shared.registerForRemoteNotifications()
         
         if let notificationOption = launchOptions?[.remoteNotification] as? [String: AnyObject] {
-            handleNotification(userInfo: notificationOption)
+            let acceptStatus = notificationOption["acceptStatus"] as? String
+            
+            switch acceptStatus {
+            case "PENDING":
+                if let boardIdStr = notificationOption["boardId"] as? String, let boardId = Int(boardIdStr) {
+                    moveApplyDetailView(boardId: boardId)
+                } else {
+                    LoggerService.shared.log(level: .error, "boardId 구할 수 없음")
+                }
+            case "ACCEPTED", nil:
+                if let chatIdStr = notificationOption["chatRoomId"] as? String, let chatId = Int(chatIdStr) {
+                    moveChatRoom(chatId: chatId)
+                } else {
+                    moveChatRoom(chatId: nil)
+                }
+            default:
+                LoggerService.shared.log(level: .error, "acceptStatus 구할 수 없음")
+            }
         }
         
         DispatchQueue.global(qos: .background).async {
@@ -61,15 +80,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
         return true
     }
-    // 푸시 알림 처리 함수
-    private func handleNotification(userInfo: [String: AnyObject]) {
-        // userInfo에서 필요한 데이터를 추출
-        if let boardIdStr = userInfo["boardId"] as? String, let boardId = Int(boardIdStr) {
-            moveApplyDetailView(boardId: boardId)
-        } else {
-            print("boardId를 구할 수 없음")
-        }
-    }
+
     // 푸시 알림 등록
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         Messaging.messaging().apnsToken = deviceToken
@@ -77,20 +88,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         let userInfo = notification.request.content.userInfo
         print("푸시 알림 수신 (foreground): \(userInfo)")
-//        let acceptStatus = userInfo["acceptStatus"] as? String
-//        
-//        switch acceptStatus {
-//        case "PENDING":
-//            if let boardIdStr = userInfo["boardId"] as? String, let boardId = Int(boardIdStr) {
-//                moveApplyDetailView(boardId: boardId)
-//            } else {
-//                LoggerService.shared.log(level: .error, "boardId 구할 수 없음")
-//            }
-//        case "ACCEPTED":
-//            moveChatRoom()
-//        default:
-//            LoggerService.shared.log(level: .error, "acceptStatus 구할 수 없음")
-//        }
         completionHandler([.list, .banner, .sound])
     }
     
@@ -106,16 +103,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             } else {
                 LoggerService.shared.log(level: .error, "boardId 구할 수 없음")
             }
-        case "ACCEPTED":
-            moveChatRoom()
+        case "ACCEPTED", nil:
+            if let chatIdStr = userInfo["chatRoomId"] as? String, let chatId = Int(chatIdStr) {
+                moveChatRoom(chatId: chatId)
+            } else {
+                moveChatRoom(chatId: nil)
+            }
         default:
             LoggerService.shared.log(level: .error, "acceptStatus 구할 수 없음")
         }
-//        if let boardIdStr = userInfo["boardId"] as? String, let boardId = Int(boardIdStr) {
-//            moveApplyDetailView(boardId: boardId)
-//        } else {
-//            print("boardId 구할 수 없음")
-//        }
         completionHandler()
     }
     private func moveApplyDetailView(boardId: Int) {
@@ -131,8 +127,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         navigationController.pushViewController(applyVC, animated: true)
     }
     
-    private func moveChatRoom() {
-        // SceneDelegate의 rootViewController 가져오기
+    private func moveChatRoom(chatId: Int?) {
         guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate,
               let tabBarController = sceneDelegate.window?.rootViewController as? UITabBarController else {
             return
@@ -145,14 +140,37 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
         
         tabBarController.selectedIndex = targetTabIndex
+        
+        // 탭 이동 후 NavigationController를 다시 가져오기 위해 async 사용
+        DispatchQueue.main.async {
+            guard let navigationController = tabBarController.selectedViewController as? UINavigationController else {
+                print("탭 변경 후 NavigationController를 찾을 수 없음")
+                return
+            }
+            
+            guard let id = SetupInfoService.shared.getUserInfo(type: .id), let userId = Int(id) else {
+                return
+            }
+            
+            let chatInfoUC = DIContainerService.shared.makeChatDetailUseCase()
+            if let chatId = chatId {
+                chatInfoUC.loadChat(chatId)
+                    .observe(on: MainScheduler.instance)
+                    .subscribe { info in
+                        let chatRoomVC = ChatRoomViewController(chat: ChatRoomInfo(chatRoomId: chatId, postInfo: info.postInfo, managerInfo: info.managerInfo, cheerTeam: info.postInfo.cheerTeam), userId: userId)
+                        navigationController.pushViewController(chatRoomVC, animated: true)
+                    }
+                    .disposed(by: self.disposeBag) // self의 disposeBag 사용
+            }
+        }
     }
-
+    
     // FCM 토큰 갱신 시 호출되는 메서드
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         print("Firebase registration token: \(String(describing: fcmToken))")
         NotificationCenter.default.post(name: Notification.Name("FCMToken"), object: nil, userInfo: ["token": fcmToken ?? ""])
     }
-
+    
     // Remote Notification 수신 시 호출되는 메서드
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         if let messageID = userInfo[gcmMessageIDKey] {
@@ -161,19 +179,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         print(userInfo)
         completionHandler(UIBackgroundFetchResult.newData)
     }
-
+    
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         print("Failed to register for remote notifications: \(error.localizedDescription)")
     }
     
     // MARK: UISceneSession Lifecycle
-
+    
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
+    
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.

--- a/CatchMate/CatchMate/APP/AppDelegate.swift
+++ b/CatchMate/CatchMate/APP/AppDelegate.swift
@@ -38,6 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         Messaging.messaging().delegate = self
         UNUserNotificationCenter.current().delegate = self
         UIApplication.shared.registerForRemoteNotifications()
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.chatInfo.chatRoomId)
         
         if let notificationOption = launchOptions?[.remoteNotification] as? [String: AnyObject] {
             let acceptStatus = notificationOption["acceptStatus"] as? String
@@ -88,6 +89,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         let userInfo = notification.request.content.userInfo
         print("푸시 알림 수신 (foreground): \(userInfo)")
+        
+        if userInfo["acceptStatus"] == nil {
+            if let chatId = userInfo["chatRoomId"] as? String {
+                if let currentChatRoomId = UserDefaults.standard.string(forKey: UserDefaultsKeys.chatInfo.chatRoomId) {
+                    print(currentChatRoomId)
+                    if currentChatRoomId == chatId {
+                        completionHandler([])
+                        return
+                    }
+                }
+            }
+        }
         completionHandler([.list, .banner, .sound])
     }
     

--- a/CatchMate/CatchMate/APP/AppDelegate.swift
+++ b/CatchMate/CatchMate/APP/AppDelegate.swift
@@ -11,6 +11,7 @@ import NaverThirdPartyLogin
 import Firebase
 import FirebaseMessaging
 import UserNotifications
+import FirebaseAnalytics
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, MessagingDelegate {

--- a/CatchMate/CatchMate/APP/AppDelegate.swift
+++ b/CatchMate/CatchMate/APP/AppDelegate.swift
@@ -25,15 +25,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 #if DEBUG
         Analytics.setAnalyticsCollectionEnabled(false) // 디버그 모드에서 비활성화
 #endif
-        // APNS 등록
-//        if #available(iOS 10.0, *) {
-//            UNUserNotificationCenter.current().delegate = self
-//            let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
-//            UNUserNotificationCenter.current().requestAuthorization(options: authOptions, completionHandler: { _, _ in })
-//        } else {
-//            let settings: UIUserNotificationSettings = UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
-//            application.registerUserNotificationSettings(settings)
-//        }
         application.registerForRemoteNotifications()
         Messaging.messaging().delegate = self
         UNUserNotificationCenter.current().delegate = self

--- a/CatchMate/CatchMate/APP/AppDelegate.swift
+++ b/CatchMate/CatchMate/APP/AppDelegate.swift
@@ -26,19 +26,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         Analytics.setAnalyticsCollectionEnabled(false) // 디버그 모드에서 비활성화
 #endif
         // APNS 등록
-        if #available(iOS 10.0, *) {
-            UNUserNotificationCenter.current().delegate = self
-            let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
-            UNUserNotificationCenter.current().requestAuthorization(options: authOptions, completionHandler: { _, _ in })
-        } else {
-            let settings: UIUserNotificationSettings = UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
-            application.registerUserNotificationSettings(settings)
-        }
+//        if #available(iOS 10.0, *) {
+//            UNUserNotificationCenter.current().delegate = self
+//            let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+//            UNUserNotificationCenter.current().requestAuthorization(options: authOptions, completionHandler: { _, _ in })
+//        } else {
+//            let settings: UIUserNotificationSettings = UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
+//            application.registerUserNotificationSettings(settings)
+//        }
         application.registerForRemoteNotifications()
         Messaging.messaging().delegate = self
         UNUserNotificationCenter.current().delegate = self
         UIApplication.shared.registerForRemoteNotifications()
-        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.chatInfo.chatRoomId)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.ChatInfo.chatRoomId)
         
         if let notificationOption = launchOptions?[.remoteNotification] as? [String: AnyObject] {
             let acceptStatus = notificationOption["acceptStatus"] as? String
@@ -92,7 +92,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         
         if userInfo["acceptStatus"] == nil {
             if let chatId = userInfo["chatRoomId"] as? String {
-                if let currentChatRoomId = UserDefaults.standard.string(forKey: UserDefaultsKeys.chatInfo.chatRoomId) {
+                if let currentChatRoomId = UserDefaults.standard.string(forKey: UserDefaultsKeys.ChatInfo.chatRoomId) {
                     print(currentChatRoomId)
                     if currentChatRoomId == chatId {
                         completionHandler([])

--- a/CatchMate/CatchMate/APP/DIContainerService.swift
+++ b/CatchMate/CatchMate/APP/DIContainerService.swift
@@ -272,4 +272,12 @@ class DIContainerService {
         let nicknameCheckUsecase = NicknameCheckUseCaseImpl(nicknameRepository: nicknameCheckRepository)
         return nicknameCheckUsecase
     }
+    
+    func makeChatDetailUseCase() -> LoadChatDetailUseCase {
+        let chatDetailDS = LoadChatDetailDataSourceImpl(tokenDataSource: tokenDS)
+        let chatDetailRepo = LoadChatDetailRepositoryImpl(loadChatDS: chatDetailDS)
+        let chatDetailUC = LoadChatDetailUseCaseImpl(loadChatRepo: chatDetailRepo)
+        
+        return chatDetailUC
+    }
 }

--- a/CatchMate/CatchMate/APP/SceneDelegate.swift
+++ b/CatchMate/CatchMate/APP/SceneDelegate.swift
@@ -87,6 +87,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+        NotificationService.shared.checkNotificationPermissionStatus { isAllowed in
+            NotificationCenter.default.post(name: .notificationStatusChanged, object: isAllowed)
+        }
     }
     
     func sceneWillResignActive(_ scene: UIScene) {

--- a/CatchMate/CatchMate/APP/SceneDelegate.swift
+++ b/CatchMate/CatchMate/APP/SceneDelegate.swift
@@ -10,7 +10,7 @@ import RxSwift
 import RxKakaoSDKAuth
 import KakaoSDKAuth
 import NaverThirdPartyLogin
-
+import FirebaseRemoteConfig
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
@@ -20,8 +20,64 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
+        let launchStoryboard = UIStoryboard(name: "LaunchScreen", bundle: nil)
+        let launchVC = launchStoryboard.instantiateViewController(withIdentifier: "LaunchScreenVC")
+        
+        window?.rootViewController = launchVC
+        window?.makeKeyAndVisible()
+        checkForUpdate()
+    }
+    
+    /// 앱 실행 전에 업데이트 체크 & 로그인 진행
+    func checkForUpdate() {
+        AppVersionService.shared.fetchRemoteConfig { minimumVersion in
+            guard let minimumVersion = minimumVersion else { return }
+            
+            let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+            
+            if AppVersionService.shared.isVersionNewer(currentVersion: currentVersion, minimumVersion: minimumVersion) {
+                DispatchQueue.main.async {
+                    self.showForceUpdateAlert()
+                }
+            } else {
+                DispatchQueue.main.async {
+                    self.attemptLogin()
+                }
+            }
+        }
+    }
+    
+    /// Alert 요청 후 앱스토어 이동
+    private func showForceUpdateAlert() {
+        DispatchQueue.main.async {
+            guard let window = self.window else { return }
+            
+            window.rootViewController?.showCMAlert(titleText: "최신 버전으로 업데이트해주세요", importantButtonText: "업데이트", commonButtonText: nil, importantAction: {
+                self.openAppStore()
+            })
+        }
+    }
+    private func openAppStore() {
+        let appID = "1234567890" // TODO: - 실제 앱 ID로 변경
+        let appStoreURL = "itms-apps://itunes.apple.com/app/id\(appID)"
+        let appStoreWebURL = "https://apps.apple.com/app/id\(appID)"
+        
+        if let url = URL(string: appStoreURL) {
+            UIApplication.shared.open(url, options: [:]) { success in
+                if !success, let webURL = URL(string: appStoreWebURL) {
+                    // 앱스토어가 안 열리면 Safari에서 앱스토어 웹페이지 열기
+                    UIApplication.shared.open(webURL, options: [:], completionHandler: nil)
+                }
+            }
+        } else if let webURL = URL(string: appStoreWebURL) {
+            // URL이 잘못되었을 경우에도 Safari에서 열기
+            UIApplication.shared.open(webURL, options: [:], completionHandler: nil)
+        }
+    }
+    private func attemptLogin() {
         let manager = AuthManager(tokenDS: TokenDataSourceImpl())
-        self.authManager = manager  // AuthManager를 강하게 참조하여 유지
+        self.authManager = manager // AuthManager를 강하게 참조하여 유지
+        
         manager.attemptAutoLogin()
             .observe(on: MainScheduler.instance)
             .withUnretained(self)
@@ -46,7 +102,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
             .disposed(by: disposeBag)
     }
-    
     private func moveMainTab() {
         let tabViewController = TabBarController()
         window?.rootViewController = tabViewController
@@ -121,7 +176,7 @@ extension SceneDelegate {
             if url.absoluteString.hasPrefix("catchmate") {
                 _ = NaverThirdPartyLoginConnection.getSharedInstance()?.application(UIApplication.shared, open: url, options: [:])
             }
-
+            
         }
         
     }

--- a/CatchMate/CatchMate/Data/DTO/DataError.swift
+++ b/CatchMate/CatchMate/Data/DTO/DataError.swift
@@ -50,9 +50,7 @@ enum TokenError: LocalizedErrorWithCode {
 enum NetworkError: LocalizedErrorWithCode {
     case notFoundBaseURL
     case disconnected
-    case slowConnection
     case responseTimeout
-    case serverUnavailable
     case clientError(statusCode: Int) // 4xx 에러
     case serverError(statusCode: Int) // 5xx 에러
     case unownedError(statusCode: Int)
@@ -73,12 +71,8 @@ enum NetworkError: LocalizedErrorWithCode {
             return -2000
         case .disconnected:
             return -2001
-        case .slowConnection:
-            return -2002
         case .responseTimeout:
-            return -2003
-        case .serverUnavailable:
-            return -2004
+            return -2002
         case .unownedError(let statusCode):
             return statusCode
         case .clientError(let statusCode):
@@ -93,12 +87,8 @@ enum NetworkError: LocalizedErrorWithCode {
             return "베이스 URL을 찾을 수 없음"
         case .disconnected:
             return "사용자 네트워크 연결 실패"
-        case .slowConnection:
-            return "사용자 네트워크 속도 문제로 인한 응답 지연"
         case .responseTimeout:
             return "사용자 타임 아웃"       
-        case .serverUnavailable:
-            return "서버 이용 불가능"
         case .clientError(let statusCode):
             return "클라이언트 요청 에러: \(statusCode)"
         case .serverError(let statusCode):

--- a/CatchMate/CatchMate/Data/DataSources/Alarm/SetAlarmDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/Alarm/SetAlarmDataSource.swift
@@ -36,7 +36,8 @@ final class SetAlarmDataSourceImpl: SetAlarmDataSource {
             "alarmType": type,
             "isEnabled": isEnabled
         ]
-        return APIService.shared.performRequest(type: .setNotification, parameters: parameters, headers: headers, encoding: JSONEncoding.default, dataType: SetNotificationResponseDTO.self, refreshToken: refreshToken)
+        print(parameters)
+        return APIService.shared.performRequest(type: .setNotification, parameters: parameters, headers: headers, encoding: URLEncoding.default, dataType: SetNotificationResponseDTO.self, refreshToken: refreshToken)
             .catch { error in
                 return Observable.error(error)
             }

--- a/CatchMate/CatchMate/Data/DataSources/Chat/LoadChatDetailDataSource.swift
+++ b/CatchMate/CatchMate/Data/DataSources/Chat/LoadChatDetailDataSource.swift
@@ -1,0 +1,50 @@
+//
+//  LoadChatDetailDataSource.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 2/23/25.
+//
+
+import UIKit
+import RxSwift
+import RxAlamofire
+import Alamofire
+
+protocol LoadChatDetailDataSource {
+    func loadChatDetail(_ chatId: Int) -> Observable<ChatRoomInfoDTO>
+}
+
+final class LoadChatDetailDataSourceImpl: LoadChatDetailDataSource {
+    private let tokenDataSource: TokenDataSource
+   
+    init(tokenDataSource: TokenDataSource) {
+        self.tokenDataSource = tokenDataSource
+    }
+    
+    func loadChatDetail(_ chatId: Int) -> RxSwift.Observable<ChatRoomInfoDTO> {
+        guard let token = tokenDataSource.getToken(for: .accessToken) else {
+            LoggerService.shared.log(level: .debug, "엑세스 토큰 찾기 실패")
+            return Observable.error(TokenError.notFoundAccessToken)
+        }
+        guard let refreshToken = self.tokenDataSource.getToken(for: .refreshToken) else {
+            LoggerService.shared.log(level: .debug, "리프레시 토큰 찾기 실패")
+            return Observable.error(TokenError.notFoundRefreshToken)
+        }
+        let headers: HTTPHeaders = [
+            "AccessToken": token
+        ]
+        
+        let addEndPoint = "\(chatId)"
+        
+        return APIService.shared.performRequest(addEndPoint: addEndPoint, type: .chatDetail, parameters: nil, headers: headers, encoding: URLEncoding.default, dataType: ChatRoomInfoDTO.self, refreshToken: refreshToken)
+            .do { dto in
+                LoggerService.shared.log("\(chatId)번 채팅방 정보 조회 성공: \(dto)")
+            }
+            .catch { error in
+                LoggerService.shared.log("\(chatId)번 채팅방 정보 조회 실패: \(error)")
+                return Observable.error(error)
+            }
+    }
+    
+    
+}

--- a/CatchMate/CatchMate/Data/DataSources/EndPoint.swift
+++ b/CatchMate/CatchMate/Data/DataSources/EndPoint.swift
@@ -75,6 +75,8 @@ enum Endpoint {
     case exitChat
     /// 채팅방 유저 강퇴
     case exportChatUser
+    /// 채팅방 1개 정보 조회
+    case chatDetail
     
     /// 내정보 조회
     case loadMyInfo
@@ -151,11 +153,12 @@ enum Endpoint {
             return "/enrolls/"
         case .chatList:
             return "/chat-rooms/list"
-        case .chatUsers, .chatImage, .exitChat, .exportChatUser:
+        case .chatUsers, .chatImage, .exitChat, .exportChatUser, .chatDetail:
             /// chat-rooms/{chatRoomId}/user-list
             /// chat-rooms/{chatRoomId}/image
             /// chat-rooms/{chatRoomId}
             /// chat-rooms/{chatRoomId}/users/{userId}
+            /// chat-rooms/{chatRoomId}
             return "/chat-rooms/"
         case .chatMessage:
             /// chats/{chatRoomId}
@@ -243,6 +246,8 @@ enum Endpoint {
             return "채팅방 나가기 API"
         case .exportChatUser:
             return "채팅방 유저 내보내기 API"
+        case .chatDetail:
+            return "채팅방 1개 정보 조회 API"
         case .loadMyInfo:
             return "내 정보 조회 API"
         case .editProfile:
@@ -312,17 +317,11 @@ enum Endpoint {
             return .patch
         case .rejectApply:
             return .patch
-        case .chatList:
-            return .get
-        case .chatUsers:
-            return .get
-        case .chatMessage:
+        case .chatList, .chatDetail, .chatUsers, .chatMessage:
             return .get
         case .chatImage:
             return .patch
-        case .exitChat:
-            return .delete
-        case .exportChatUser:
+        case .exitChat, .exportChatUser:
             return .delete
         case .loadMyInfo:
             return .get

--- a/CatchMate/CatchMate/Data/Mapper/ApplyMapper.swift
+++ b/CatchMate/CatchMate/Data/Mapper/ApplyMapper.swift
@@ -57,10 +57,15 @@ final class ApplyMapper {
                 LoggerService.shared.log("Received Apply Mapping(\(enrollInfo.enrollId)번 신청 - User 정보 매칭 실패")
                 return nil
             }
+            guard let date = DateHelper.shared.convertISOStringToDate(enrollInfo.requestDate) else {
+                LoggerService.shared.log("Received Apply Mapping(\(enrollInfo.enrollId)번 신청 - Date parsing 실패")
+                return nil
+            }
             return RecivedApplyData(
                 enrollId: String(enrollInfo.enrollId),
                 user: user,
                 addText: enrollInfo.description,
+                requestDate: date,
                 new: enrollInfo.isNew
             )
         }

--- a/CatchMate/CatchMate/Data/Repositories/Chat/LoadChatDetailRepositoryImpl.swift
+++ b/CatchMate/CatchMate/Data/Repositories/Chat/LoadChatDetailRepositoryImpl.swift
@@ -1,0 +1,27 @@
+//
+//  LoadChatDetailRepositoryImpl.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 2/23/25.
+//
+import RxSwift
+
+final class LoadChatDetailRepositoryImpl: LoadChatDetailRepository {
+    private let loadChatDS: LoadChatDetailDataSource
+    init(loadChatDS: LoadChatDetailDataSource) {
+        self.loadChatDS = loadChatDS
+    }
+    
+    func loadChat(_ chatId: Int) -> RxSwift.Observable<ChatListInfo> {
+        return loadChatDS.loadChatDetail(chatId)
+            .flatMap { dto -> Observable<ChatListInfo> in
+                let chatMapper = ChatMapper()
+                guard let mappingResult = chatMapper.dtoToDomain(dto) else {
+                    return Observable.error(MappingError.invalidData)
+                }
+                return Observable.just(mappingResult)
+            }
+    }
+    
+    
+}

--- a/CatchMate/CatchMate/DesignSystem/Base/BaseViewController.swift
+++ b/CatchMate/CatchMate/DesignSystem/Base/BaseViewController.swift
@@ -149,9 +149,6 @@ class BaseViewController: UIViewController, LayoutConfigurable {
             }
         case .unauthorized:
             logout()
-        case .chatError:
-            // TODO: - 상단 메시지창으로 바꾸기
-            showToast(message: "채팅방 연결이 불안정 합니다.", buttonContainerExists: buttonContainerExists)
         }
     }
     

--- a/CatchMate/CatchMate/DesignSystem/Components/CMSwitch.swift
+++ b/CatchMate/CatchMate/DesignSystem/Components/CMSwitch.swift
@@ -74,9 +74,9 @@ class CMSwitch: UIControl {
     }
     
     @objc private func didTap() {
-        isOn.toggle()
+//        isOn.toggle()
         sendActions(for: .valueChanged)
-        updateUI(animated: true)
+//        updateUI(animated: true)
     }
     
     private func updateUI(animated: Bool) {

--- a/CatchMate/CatchMate/Domain/Model/Apply/ApplyList.swift
+++ b/CatchMate/CatchMate/Domain/Model/Apply/ApplyList.swift
@@ -59,6 +59,7 @@ struct RecivedApplyData: Equatable {
     let enrollId: String
     let user: SimpleUser
     let addText: String
+    let requestDate: Date
     var new: Bool
     
     static func == (lhs: RecivedApplyData, rhs: RecivedApplyData) -> Bool {

--- a/CatchMate/CatchMate/Domain/Model/Chat/ChatMessage.swift
+++ b/CatchMate/CatchMate/Domain/Model/Chat/ChatMessage.swift
@@ -69,6 +69,7 @@ struct ChatSocketMessage: Codable {
     let content: String
     let sendTime: String // "2025-01-31T15:20:00" - ISO8601 포맷
     
+    static let timeFormat = "yyyy-MM-dd'T'HH:mm:ss"
     init(messageType: ChatMessageType, senderId: Int, content: String) {
         self.messageType = messageType.serverRequest
         self.senderId = senderId
@@ -98,8 +99,8 @@ struct ChatSocketMessage: Codable {
     
     static func currentISO8601Time() -> String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-        formatter.timeZone = TimeZone.current // 로컬 시간
+        formatter.dateFormat = self.timeFormat
+        formatter.timeZone = TimeZone(identifier: "UTC")
         return formatter.string(from: Date())
     }
 }

--- a/CatchMate/CatchMate/Domain/Repositories/Chat/LoadChatDetailRepository.swift
+++ b/CatchMate/CatchMate/Domain/Repositories/Chat/LoadChatDetailRepository.swift
@@ -1,0 +1,12 @@
+//
+//  LoadChatDetailRepository.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 2/23/25.
+//
+
+import RxSwift
+
+protocol LoadChatDetailRepository {
+    func loadChat(_ chatId: Int) -> Observable<ChatListInfo>
+}

--- a/CatchMate/CatchMate/Domain/UseCases/Chat/LoadChatDetailUseCase.swift
+++ b/CatchMate/CatchMate/Domain/UseCases/Chat/LoadChatDetailUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  LoadChatDetailUseCase.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 2/23/25.
+//
+
+import RxSwift
+
+protocol LoadChatDetailUseCase {
+    func loadChat(_ chatId: Int) -> Observable<ChatListInfo>
+}
+
+final class LoadChatDetailUseCaseImpl: LoadChatDetailUseCase {
+    private let loadChatRepo: LoadChatDetailRepository
+    init(loadChatRepo: LoadChatDetailRepository) {
+        self.loadChatRepo = loadChatRepo
+    }
+    
+    func loadChat(_ chatId: Int) -> RxSwift.Observable<ChatListInfo> {
+        return loadChatRepo.loadChat(chatId)
+            .catch { error in
+                let domainError = DomainError(error: error, context: .action, message: "채팅방 정보 불러오기 실패")
+                LoggerService.shared.errorLog(domainError, domain: "load_chatdetail", message: error.errorDescription)
+                return Observable.error(domainError)
+            }
+    }
+    
+    
+}

--- a/CatchMate/CatchMate/Presentaions/Error/ErrorMapper.swift
+++ b/CatchMate/CatchMate/Presentaions/Error/ErrorMapper.swift
@@ -19,8 +19,11 @@ final class ErrorMapper {
                 return .unauthorized
             }
         }
+        
+
         // TODO: - Logging 추가
         // DomainError가 아닐 경우 -> 알 수 없는 에러
+        LoggerService.shared.errorLog(error, domain: "errormapper", message: "알 수 없는 에러: \(error.errorDescription)")
         return .showErrorPage
     }
 }

--- a/CatchMate/CatchMate/Presentaions/Error/PresentationError.swift
+++ b/CatchMate/CatchMate/Presentaions/Error/PresentationError.swift
@@ -7,9 +7,8 @@
 
 import Foundation
 
-enum PresentationError: LocalizedError {
+enum PresentationError: LocalizedError, Equatable {
     case showErrorPage
     case showToastMessage(message: String)
     case unauthorized     // 인증 실패
-    case chatError
 }

--- a/CatchMate/CatchMate/Presentaions/View/AddPost/AddViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/AddPost/AddViewController.swift
@@ -68,7 +68,7 @@ final class AddViewController: BaseViewController, View {
         label.text = "명"
         label.textColor = UIColor.lightGray
         return label
-    }(), placeHolder: "최대 8", isFlex: true)
+    }(), placeHolder: "본인 포함 인원", isFlex: true)
     
     private let matchInfoLabel: UILabel = {
         let label = UILabel()

--- a/CatchMate/CatchMate/Presentaions/View/AddPost/AddViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/AddPost/AddViewController.swift
@@ -273,6 +273,7 @@ extension AddViewController {
             .disposed(by: disposeBag)
         
         registerButton.rx.tap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .withUnretained(self)
             .subscribe(onNext: { vc, _ in
                 if vc.editPost != nil {

--- a/CatchMate/CatchMate/Presentaions/View/Chat/ChatListTableViewCell.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Chat/ChatListTableViewCell.swift
@@ -92,7 +92,7 @@ final class ChatListTableViewCell: UITableViewCell {
         ImageLoadHelper.loadImage(chatImageView, pictureString: chat.chatImage, defaultImage: defaultImage)
         postTitleLabel.text = chat.postInfo.title
         newChat = chat.newChat
-        lastChatLabel.text = newChat ? "채팅을 시작해보세요." : (chat.lastMessage.isEmpty ? "채팅을 시작해보세요." : chat.lastMessage)
+        lastChatLabel.text = (chat.lastMessage.isEmpty ? "채팅을 시작해보세요." : chat.lastMessage)
         newMessageCount = chat.notReadCount
         notiBadge.setBadgeCount(newMessageCount)
         notiBadge.isHidden = newMessageCount == 0 ? true : false

--- a/CatchMate/CatchMate/Presentaions/View/Chat/ChatRoomViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Chat/ChatRoomViewController.swift
@@ -324,6 +324,7 @@ extension ChatRoomViewController {
             .disposed(by: disposeBag)
         
         inputview.rx.sendTap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .compactMap { $0 }
             .distinctUntilChanged()
             .withUnretained(self)

--- a/CatchMate/CatchMate/Presentaions/View/Chat/ChatRoomViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Chat/ChatRoomViewController.swift
@@ -342,8 +342,14 @@ extension ChatRoomViewController {
                 vc.updateCurrentPeople(count)
             }
             .disposed(by: disposeBag)
-        
-        reactor.state.map {$0.error}
+        reactor.state.map{$0.error}
+            .compactMap{$0}
+            .withUnretained(self)
+            .subscribe { vc, error in
+                vc.handleError(error)
+            }
+            .disposed(by: disposeBag)
+        reactor.state.map {$0.chatError}
             .map{ $0 == nil }
             .distinctUntilChanged()
             .withUnretained(self)

--- a/CatchMate/CatchMate/Presentaions/View/Chat/ChatSettingViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Chat/ChatSettingViewController.swift
@@ -159,12 +159,14 @@ extension ChatSettingViewController {
             .disposed(by: disposeBag)
         
         exitButton.rx.tap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .withUnretained(self)
             .subscribe { vc, _ in
                 vc.dismiss(animated: false)
             }
             .disposed(by: disposeBag)
         imageEditButton.rx.tap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .withUnretained(self)
             .subscribe { vc, _ in
                 vc.openLibrary()

--- a/CatchMate/CatchMate/Presentaions/View/Favorite/FavoriteListViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Favorite/FavoriteListViewController.swift
@@ -98,6 +98,7 @@ final class FavoriteListViewController: BaseViewController ,View {
 
 
                 cell.tapEvent
+                    .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
                     .withUnretained(cell)
                     .map { $0.0.post }
                     .compactMap { $0 }

--- a/CatchMate/CatchMate/Presentaions/View/Home/ApplyPopupViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/ApplyPopupViewController.swift
@@ -171,6 +171,7 @@ final class ApplyPopupViewController: UIViewController, View {
 extension ApplyPopupViewController {
     func bind(reactor: PostReactor) {
         commonButton.rx.tap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .withUnretained(self)
             .subscribe { vc, _ in
                 if vc.apply != nil {
@@ -182,6 +183,7 @@ extension ApplyPopupViewController {
             .disposed(by: disposeBag)
         
         primaryButton.rx.tap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .withUnretained(self)
             .subscribe(onNext: { vc, _ in
                 if vc.apply != nil {

--- a/CatchMate/CatchMate/Presentaions/View/Home/HomeViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/HomeViewController.swift
@@ -56,6 +56,14 @@ final class HomeViewController: BaseViewController, View {
         tabBarController?.tabBar.isHidden = false
         reactor.action.onNext(.selectPost(nil))
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        NotificationService.shared.requestNotificationPermission { granted in
+            let message = granted ? "✅ 알림 권한이 허용되었습니다." : "❌ 알림 권한이 거부되었습니다."
+            LoggerService.shared.log(level: .info, message)
+        }
+    }
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .grayScale50

--- a/CatchMate/CatchMate/Presentaions/View/Home/HomeViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/HomeViewController.swift
@@ -78,6 +78,10 @@ final class HomeViewController: BaseViewController, View {
         bind(reactor: self.reactor)
         reactor.action.onNext(.setupUserInfo)
         filterScrollView.showsHorizontalScrollIndicator = false
+        AppVersionService.shared.fetchLatestVersion { version in
+            print("currentAPPStoreVersion: \(version)")
+        }
+        print("currentVersion: \(AppVersionService.shared.getCurrentAppVersion())")
     }
     private func setupNavigation() {
         let notiButton = UIButton()

--- a/CatchMate/CatchMate/Presentaions/View/Home/HomeViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/HomeViewController.swift
@@ -55,6 +55,9 @@ final class HomeViewController: BaseViewController, View {
         super.viewWillAppear(true)
         tabBarController?.tabBar.isHidden = false
         reactor.action.onNext(.selectPost(nil))
+        if reactor.currentState.posts.isEmpty {
+            reactor.action.onNext(.setupUserInfo)
+        }
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/CatchMate/CatchMate/Presentaions/View/Home/HomeViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/HomeViewController.swift
@@ -78,7 +78,7 @@ final class HomeViewController: BaseViewController, View {
         bind(reactor: self.reactor)
         reactor.action.onNext(.setupUserInfo)
         filterScrollView.showsHorizontalScrollIndicator = false
-        AppVersionService.shared.fetchLatestVersion { version in
+        AppVersionService.shared.fetchRemoteConfig { version in
             print("currentAPPStoreVersion: \(version)")
         }
         print("currentVersion: \(AppVersionService.shared.getCurrentAppVersion())")

--- a/CatchMate/CatchMate/Presentaions/View/Home/NumberPickerViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/NumberPickerViewController.swift
@@ -12,7 +12,7 @@ import ReactorKit
 final class NumberPickerViewController: BasePickerViewController , View {
     private let picker: UIPickerView = UIPickerView()
     private var selectedNum: Int = 1
-    private let numberArr: [Int] = [1,2,3,4,5,6,7,8]
+    private let numberArr: [Int] = [2,3,4,5,6,7,8]
     private let resetButton: UIButton = {
         let button = UIButton()
         button.setTitle("초기화", for: .normal)

--- a/CatchMate/CatchMate/Presentaions/View/Home/PostDetailViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Home/PostDetailViewController.swift
@@ -465,6 +465,9 @@ extension PostDetailViewController {
     private func setupFavoriteButton(_ state: Bool) {
         if state {
             favoriteButton.setImage(UIImage(named: "favoriteGray_filled")?.withTintColor(.cmPrimaryColor, renderingMode: .alwaysOriginal), for: .normal)
+            if reactor.currentState.isLoadSetting {
+                showToast(message: "게시물을 저장했어요", buttonContainerExists: true)
+            }
         } else {
             favoriteButton.setImage(UIImage(named: "favoriteGray_filled")?.withRenderingMode(.alwaysOriginal), for: .normal)
         }

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/MyMenus/ReceiveMateListDetailViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/MyMenus/ReceiveMateListDetailViewController.swift
@@ -214,8 +214,7 @@ final class DetailCardCell: UICollectionViewCell {
         ageLabel.backgroundColor = .grayScale100
         ageLabel.textColor = .cmNonImportantTextColor
         ageLabel.applyStyle(textStyle: FontSystem.caption01_medium)
-        // MARK: - API CreateDate 추가 시 수정
-        applyDateLabel.text = DateHelper.shared.toString(from: Date(), format: "M월d일 HH:mm")
+        applyDateLabel.text = DateHelper.shared.toString(from: apply.requestDate, format: "M월d일 HH:mm")
         applyDateLabel.applyStyle(textStyle: FontSystem.body02_medium)
         textView.text = apply.addText
         textView.applyStyle(textStyle: FontSystem.body02_medium)

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/MyMenus/ReceiveMateListDetailViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/MyMenus/ReceiveMateListDetailViewController.swift
@@ -72,11 +72,13 @@ final class ReceiveMateListDetailViewController: BaseViewController, UICollectio
             .bind(to: collectionView.rx.items(cellIdentifier: "DetailCardCell", cellType: DetailCardCell.self)) { index, apply, cell in
                 cell.configData(apply: apply)
                 cell.primaryButton.rx.tap
+                    .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
                     .map { Reactor.Action.acceptApply(apply.enrollId) }
                     .bind(to: reactor.action)
                     .disposed(by: cell.disposeBag)
                 
                 cell.commonButton.rx.tap
+                    .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
                     .map { Reactor.Action.rejectApply(apply.enrollId) }
                     .bind(to: reactor.action)
                     .disposed(by: cell.disposeBag)

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/MyMenus/ReceiveMateListViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/MyMenus/ReceiveMateListViewController.swift
@@ -34,12 +34,12 @@ final class ReceiveMateListViewController: BaseViewController, View {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         reactor.action.onNext(.loadReceiveAppliesAll)
-        reactor.action.onNext(.selectPost(nil))
+        reactor.action.onNext(.selectPost(nil, nil))
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        reactor.action.onNext(.selectPost(isPushId))
+        reactor.action.onNext(.selectPost(nil, isPushId))
     }
     
     override func viewDidLoad() {
@@ -79,7 +79,7 @@ extension ReceiveMateListViewController {
         tableView.rx.itemSelected
             .subscribe { indexPath in
                 let apply = reactor.currentState.recivedApplies[indexPath.row]
-                reactor.action.onNext(.selectPost(apply.post.id))
+                reactor.action.onNext(.selectPost(indexPath.row, apply.post.id))
             }
             .disposed(by: disposeBag)
         

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/MyPageRoot/MyPageViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/MyPageRoot/MyPageViewController.swift
@@ -145,6 +145,7 @@ class MyPageViewController: BaseViewController, UITableViewDelegate, UITableView
         case 1:
             if let user = user {
                 myMenus[indexPath.row].navigationVC(user: SimpleUser(user: user))
+                    .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
                     .withUnretained(self)
                     .subscribe { vc, nextVC in
                         nextVC.hidesBottomBarWhenPushed = true
@@ -154,6 +155,7 @@ class MyPageViewController: BaseViewController, UITableViewDelegate, UITableView
             }
         case 2:
             supportMenus[indexPath.row].navigationVC()
+                .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
                 .withUnretained(self)
                 .subscribe { vc, nextVC in
                     nextVC.hidesBottomBarWhenPushed = true

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/ProfileEdit/ProfileEditViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/ProfileEdit/ProfileEditViewController.swift
@@ -102,6 +102,7 @@ final class ProfileEditViewController: BaseViewController, View {
         bind(reactor: reactor)
         view.backgroundColor = .grayScale50
         imgPicker.delegate = self
+        imgPicker.allowsEditing = true
         setupImage()
     }
     private func setupImage() {
@@ -127,7 +128,7 @@ final class ProfileEditViewController: BaseViewController, View {
 // MARK: - ImagePicker
 extension ProfileEditViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-        if let image = info[.originalImage] as? UIImage {
+        if let image = info[.editedImage] as? UIImage {
             if let validImage = UIImage(data: image.jpegData(compressionQuality: 0.5)!) {
                 reactor.action.onNext(.changeImage(validImage))
             } else {

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/ProfileEdit/ProfileEditViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/ProfileEdit/ProfileEditViewController.swift
@@ -147,7 +147,11 @@ extension ProfileEditViewController {
         imageEditButton.rx.tap
             .withUnretained(self)
             .subscribe { vc, _ in
-                vc.openLibrary()
+                PhotoPermissionService.shared.checkPermission(from: self) { result in
+                    if result {
+                        self.openLibrary()
+                    }
+                }
             }
             .disposed(by: disposeBag)
         self.nicknameTextField.text = reactor.currentState.nickname

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/ProfileEdit/ProfileEditViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/ProfileEdit/ProfileEditViewController.swift
@@ -169,6 +169,7 @@ extension ProfileEditViewController {
             .disposed(by: disposeBag)
         
         saveButton.rx.tap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .withUnretained(self)
             .subscribe {vc,  _ in
                 if reactor.currentState.nickNameValidate == .failed {

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/Supports/ApplicationInfoViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/Supports/ApplicationInfoViewController.swift
@@ -58,11 +58,17 @@ final class ApplicationInfoViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupLeftTitle("정보")
+        setupAppVersion()
         setupUI()
         bind()
     }
     
-
+    private func setupAppVersion() {
+        if let version = AppVersionService.shared.getCurrentAppVersion() {
+            versionLabel.text = "v.\(version)"
+            versionLabel.applyStyle(textStyle: FontSystem.body02_medium)
+        }
+    }
     private func setupUI() {
         view.backgroundColor = .cmGrayBackgroundColor
         appVersionView.backgroundColor = .cmBackgroundColor

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/Supports/CustomerServiceAddViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/Supports/CustomerServiceAddViewController.swift
@@ -79,7 +79,7 @@ final class CustomerServiceAddViewController: BaseViewController, View {
             .filter{$0}
             .withUnretained(self)
             .subscribe { vc, _ in
-                vc.navigationController?.popViewController(animated: true)
+                vc.navigationController?.popToRootViewController(animated: true)
             }
             .disposed(by: disposeBag)
         

--- a/CatchMate/CatchMate/Presentaions/View/MyPage/Supports/CustomerServiceAddViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/MyPage/Supports/CustomerServiceAddViewController.swift
@@ -61,6 +61,7 @@ final class CustomerServiceAddViewController: BaseViewController, View {
     
     func bind(reactor: CustomerServiceReactor) {
         submitButton.rx.tap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .subscribe { _ in
                 reactor.action.onNext(.submitContent)
             }

--- a/CatchMate/CatchMate/Presentaions/View/Sign/InputCheerStyleViewController.swift
+++ b/CatchMate/CatchMate/Presentaions/View/Sign/InputCheerStyleViewController.swift
@@ -154,6 +154,7 @@ extension InputCheerStyleViewController {
             .disposed(by: disposeBag)
         
         nextButton.rx.tap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
             .withUnretained(self)
             .subscribe { vc, _ in
                 if let model = reactor.currentState.signUpModel {

--- a/CatchMate/CatchMate/Presentaions/ViewModel/AlarmSettingReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/AlarmSettingReactor.swift
@@ -13,6 +13,7 @@ import ReactorKit
 final class AlarmSettingReactor: Reactor {
     enum Action {
         case loadNotificationInfo
+        case rejectAlarm
         case toggleSwitch((type: AlarmnType, state: Bool))
         case setError(PresentationError?)
     }
@@ -78,6 +79,10 @@ final class AlarmSettingReactor: Reactor {
             }
         case .setError(let error):
             return Observable.just(.setError(error))
+        case .rejectAlarm:
+            return Observable.concat([
+                Observable.just(.setAllAlarm(false))
+            ])
         }
     }
     func reduce(state: State, mutation: Mutation) -> State {
@@ -90,13 +95,13 @@ final class AlarmSettingReactor: Reactor {
             newState.eventAlarm = state
         case .setApplyAlarm(let state):
             newState.applyAlarm = state
-            if state == false { newState.allAlarm = false }
+            newState.allAlarm = isAllAlarmAllowed(newState)
         case .setChatAlarm(let state):
             newState.chatAlarm = state
-            if state == false { newState.allAlarm = false }
+            newState.allAlarm = isAllAlarmAllowed(newState)
         case .setEventAlarm(let state):
             newState.eventAlarm = state
-            if state == false { newState.allAlarm = false }
+            newState.allAlarm = isAllAlarmAllowed(newState)
         case .setNotificationInfo(let info):
             newState.allAlarm = info.all
             newState.applyAlarm = info.apply
@@ -106,5 +111,13 @@ final class AlarmSettingReactor: Reactor {
             newState.error = error
         }
         return newState
+    }
+    
+    private func isAllAlarmAllowed(_ newState: State) -> Bool {
+        let chatAlarm = newState.chatAlarm
+        let eventAlarm = newState.eventAlarm
+        let applyAlarm = newState.applyAlarm
+        
+        return chatAlarm && eventAlarm && applyAlarm
     }
 }

--- a/CatchMate/CatchMate/Presentaions/ViewModel/HomeReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/HomeReactor.swift
@@ -86,7 +86,10 @@ final class HomeReactor: Reactor {
                 })
                 .withUnretained(self)
                 .flatMap({ reactor, _ in
-                    return reactor.updateFiltersAndLoadPosts(date: nil, teams: nil, number: nil)
+                    let date = reactor.currentState.dateFilterValue
+                    let teams = reactor.currentState.selectedTeams
+                    let number = reactor.currentState.seletedNumberFilter
+                    return reactor.updateFiltersAndLoadPosts(date: date, teams: teams, number: number)
                 })
                 .catch { error in
                     return Observable.just(Mutation.setError(ErrorMapper.mapToPresentationError(error)))

--- a/CatchMate/CatchMate/Presentaions/ViewModel/PostReactor.swift
+++ b/CatchMate/CatchMate/Presentaions/ViewModel/PostReactor.swift
@@ -54,6 +54,7 @@ final class PostReactor: Reactor {
         case setApplyInfo(MyApplyInfo?)
         case deletePost
         case setError(PresentationError?)
+        case setIsLoadSetting
         case setUpPostResult((result: Bool, message: String?)?)
     }
     struct State {
@@ -64,6 +65,7 @@ final class PostReactor: Reactor {
         var applyInfo: MyApplyInfo?
         var isDelete: Bool = false
         var upPostResult: (result: Bool, message: String?)?
+        var isLoadSetting: Bool = false
         var error: PresentationError?
     }
     var postId: String
@@ -93,7 +95,8 @@ final class PostReactor: Reactor {
                     var mutations: [Observable<Mutation>] = [
                         Observable.just(Mutation.setPost(post)),
                         Observable.just(Mutation.setApplyButtonState(state)),
-                        Observable.just(Mutation.setIsFavorite(favorite))
+                        Observable.just(Mutation.setIsFavorite(favorite)),
+                        Observable.just(Mutation.setIsLoadSetting)
                     ]
                     if state == .applied {
                         let applyInfoMutation = self.postDetailUsecase.loadApplyInfo(postId: self.postId)
@@ -199,6 +202,8 @@ final class PostReactor: Reactor {
             newState.isDelete = true
         case .setUpPostResult(let result):
             newState.upPostResult = result
+        case .setIsLoadSetting:
+            newState.isLoadSetting = true
         }
         return newState
     }

--- a/CatchMate/CatchMate/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/CatchMate/CatchMate/Resources/Base.lproj/LaunchScreen.storyboard
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,8 +15,21 @@
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logo_white" translatesAutoresizingMaskIntoConstraints="NO" id="ElL-S9-eEW">
+                                <rect key="frame" x="136.66666666666666" y="366" width="119.99999999999997" height="120"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="120" id="2qw-K0-YtF"/>
+                                    <constraint firstAttribute="height" constant="120" id="btP-GB-0b4"/>
+                                </constraints>
+                            </imageView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" red="0.99215686274509807" green="0.36862745098039218" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="ElL-S9-eEW" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="KY6-Mx-xmJ"/>
+                            <constraint firstItem="ElL-S9-eEW" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="xVd-Sr-fwn"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -26,8 +38,6 @@
         </scene>
     </scenes>
     <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
+        <image name="logo_white" width="200" height="200"/>
     </resources>
 </document>

--- a/CatchMate/CatchMate/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/CatchMate/CatchMate/Resources/Base.lproj/LaunchScreen.storyboard
@@ -11,7 +11,7 @@
         <!--View Controller-->
         <scene sceneID="EHf-IW-A2E">
             <objects>
-                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LaunchScreenVC" id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/CatchMate/CatchMate/Utilities/Constraints/UserDefaultsKeys.swift
+++ b/CatchMate/CatchMate/Utilities/Constraints/UserDefaultsKeys.swift
@@ -17,7 +17,11 @@ enum UserDefaultsKeys {
             static let imageUrl = "UserImageUrl"
         }
     }
-    enum chatInfo {
+    enum ChatInfo {
         static let chatRoomId = "ChatRoomId"
+    }
+    
+    enum AlarmSetup {
+        static let alarmSetup = "hasRequestedNotification"
     }
 }

--- a/CatchMate/CatchMate/Utilities/Constraints/UserDefaultsKeys.swift
+++ b/CatchMate/CatchMate/Utilities/Constraints/UserDefaultsKeys.swift
@@ -17,4 +17,7 @@ enum UserDefaultsKeys {
             static let imageUrl = "UserImageUrl"
         }
     }
+    enum chatInfo {
+        static let chatRoomId = "ChatRoomId"
+    }
 }

--- a/CatchMate/CatchMate/Utilities/Extensions/Notification+Extension.swift
+++ b/CatchMate/CatchMate/Utilities/Extensions/Notification+Extension.swift
@@ -1,0 +1,12 @@
+//
+//  Notification+Extension.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 2/24/25.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let notificationStatusChanged = Notification.Name("notificationStatusChanged")
+}

--- a/CatchMate/CatchMate/Utilities/Service/AppVersionService.swift
+++ b/CatchMate/CatchMate/Utilities/Service/AppVersionService.swift
@@ -1,0 +1,40 @@
+//
+//  AppVersionService.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 2/25/25.
+//
+import Foundation
+
+final class AppVersionService {
+    static let shared = AppVersionService()
+    func fetchLatestVersion(completion: @escaping (String?) -> Void) {
+        guard let url = URL(string: "https://itunes.apple.com/lookup?bundleId=com.tori.CatchMate") else {
+            completion(nil)
+            return
+        }
+        
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            guard let data = data, error == nil else {
+                completion(nil)
+                return
+            }
+            
+            do {
+                if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                   let results = json["results"] as? [[String: Any]],
+                   let latestVersion = results.first?["version"] as? String {
+                    completion(latestVersion)
+                } else {
+                    completion(nil)
+                }
+            } catch {
+                completion(nil)
+            }
+        }.resume()
+    }
+    
+    func getCurrentAppVersion() -> String? {
+        return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+}

--- a/CatchMate/CatchMate/Utilities/Service/AppVersionService.swift
+++ b/CatchMate/CatchMate/Utilities/Service/AppVersionService.swift
@@ -5,36 +5,49 @@
 //  Created by 방유빈 on 2/25/25.
 //
 import Foundation
+import FirebaseRemoteConfig
+import Alamofire
 
 final class AppVersionService {
     static let shared = AppVersionService()
-    func fetchLatestVersion(completion: @escaping (String?) -> Void) {
-        guard let url = URL(string: "https://itunes.apple.com/lookup?bundleId=com.tori.CatchMate") else {
-            completion(nil)
-            return
-        }
-        
-        URLSession.shared.dataTask(with: url) { data, _, error in
-            guard let data = data, error == nil else {
+    private let remoteConfig = RemoteConfig.remoteConfig()
+    
+    private init() {
+        let settings = RemoteConfigSettings()
+        settings.minimumFetchInterval = 0
+        remoteConfig.configSettings = settings
+
+        // 기본값 설정
+        remoteConfig.setDefaults([
+            "minimum_version": "1.0.0" as NSObject
+        ])
+    }
+    
+    func fetchRemoteConfig(completion: @escaping (String?) -> Void) {
+        remoteConfig.fetchAndActivate { status, error in
+            if let error = error {
+                print("⚠️ Remote Config 가져오기 실패: \(error.localizedDescription)")
                 completion(nil)
                 return
             }
-            
-            do {
-                if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-                   let results = json["results"] as? [[String: Any]],
-                   let latestVersion = results.first?["version"] as? String {
-                    completion(latestVersion)
-                } else {
-                    completion(nil)
-                }
-            } catch {
-                completion(nil)
-            }
-        }.resume()
+            let minimumVersion = self.remoteConfig["minimum_version"].stringValue ?? "1.0.0"
+            completion(minimumVersion)
+        }
     }
     
     func getCurrentAppVersion() -> String? {
         return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+    
+    func isVersionNewer(currentVersion: String, minimumVersion: String) -> Bool {
+        let currentComponents = currentVersion.split(separator: ".").map { Int($0) ?? 0 }
+        let minimumComponents = minimumVersion.split(separator: ".").map { Int($0) ?? 0 }
+
+        for (current, minimum) in zip(currentComponents, minimumComponents) {
+            if current < minimum { return true }  // 현재 버전이 더 낮음 → 업데이트 필요
+            if current > minimum { return false } // 현재 버전이 최신임 → 업데이트 불필요
+        }
+
+        return currentComponents.count < minimumComponents.count // 길이가 짧으면 오래된 버전
     }
 }

--- a/CatchMate/CatchMate/Utilities/Service/NotificationService.swift
+++ b/CatchMate/CatchMate/Utilities/Service/NotificationService.swift
@@ -1,0 +1,83 @@
+//
+//  NotificationService.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 2/24/25.
+//
+
+import UserNotifications
+import Alamofire
+final class NotificationService {
+    static let shared = NotificationService()
+
+    private let tokenDS: TokenDataSource = TokenDataSourceImpl()
+    private init() {}
+
+    /// 알림 권한 요청 함수
+    func requestNotificationPermission(completion: @escaping (Bool) -> Void) {
+        let hasRequestedBefore = UserDefaults.standard.object(forKey: UserDefaultsKeys.AlarmSetup.alarmSetup) != nil
+        
+        // 이미 요청한 적이 있다면 다시 요청하지 않음
+        if hasRequestedBefore {
+            checkNotificationPermissionStatus(completion: completion)
+            return
+        }
+        
+        let center = UNUserNotificationCenter.current()
+        
+        center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            DispatchQueue.main.async {
+                if let error = error {
+                    print("알림 권한 요청 오류: \(error.localizedDescription)")
+                }
+                completion(granted)
+                UserDefaults.standard.setValue(granted, forKey: UserDefaultsKeys.AlarmSetup.alarmSetup)
+                // 허용 시 서버로 전송
+                self.sendNotificationPermissionToServer(granted)
+            }
+        }
+    }
+
+    /// 서버로 알림 허용 여부 전송
+    func sendNotificationPermissionToServer(_ isAllow: Bool) {
+        guard let base = Bundle.main.baseURL else {
+            LoggerService.shared.log(level: .error, "Base URL 찾을 수 없음")
+            return
+        }
+        let url = base+"/users/alarm"
+        guard let token = tokenDS.getToken(for: .accessToken) else {
+            LoggerService.shared.log(level: .error, "엑세스 토큰 찾기 실패")
+            return
+        }
+
+        let headers: HTTPHeaders = [
+            "AccessToken": token
+        ]
+        let parmeters: [String: Any] = [
+            "alarmType": "ALL",
+            "isEnabled": isAllow ? "Y" : "N"
+        ]
+        AF.request(url, method: .patch, parameters: parmeters, encoding: URLEncoding.default, headers: headers)
+            .validate(statusCode: 200..<300)
+            .response { response in
+                switch response.result {
+                case .success:
+                    print("✅ 서버 전송 성공")
+                case .failure(let error):
+                    LoggerService.shared.errorLog(error, domain: "set_notification", message: "알림 권한 설정 서버 전송 실패")
+                    print("❌ 서버 전송 실패: \(error.localizedDescription)")
+                }
+            }
+    }
+
+    /// 현재 알림 권한 상태 확인
+    func checkNotificationPermissionStatus(completion: @escaping (Bool) -> Void) {
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                let isAllowed = (settings.authorizationStatus == .authorized)
+                completion(isAllowed)
+            }
+        }
+    }
+}

--- a/CatchMate/CatchMate/Utilities/Service/PhotoPermissionService.swift
+++ b/CatchMate/CatchMate/Utilities/Service/PhotoPermissionService.swift
@@ -1,0 +1,56 @@
+//
+//  PhotoPermissionService.swift
+//  CatchMate
+//
+//  Created by 방유빈 on 2/25/25.
+//
+import UIKit
+import Photos
+
+final class PhotoPermissionService {
+    static let shared = PhotoPermissionService()
+    
+    
+    /// 갤러리 접근 권한 확인 및 요청
+    func checkPermission(from viewController: UIViewController, completion: @escaping (Bool) -> Void) {
+        let status = PHPhotoLibrary.authorizationStatus()
+
+        switch status {
+        case .authorized, .limited:
+            print("✅ 갤러리 접근 허용됨")
+            completion(true)
+        case .denied, .restricted:
+            print("❌ 갤러리 접근 거부됨")
+            self.showPermissionAlert(viewController: viewController)
+            completion(false)
+        case .notDetermined:
+            print("❓ 아직 사용자가 선택하지 않음")
+            requestPermission(viewController: viewController, completion: completion)
+        @unknown default:
+            completion(false)
+        }
+    }
+    
+    /// 처음 권한 요청
+    private func requestPermission(viewController: UIViewController, completion: @escaping (Bool) -> Void) {
+        PHPhotoLibrary.requestAuthorization { status in
+            DispatchQueue.main.async {
+                if status == .authorized || status == .limited {
+                    completion(true) // ✅ 권한 허용됨
+                } else {
+                    self.showPermissionAlert(viewController: viewController) // ❌ 거부됨 → 설정 이동 유도
+                    completion(false)
+                }
+            }
+        }
+    }
+
+    /// 설정으로 이동 유도 (권한 거부 시)
+    private func showPermissionAlert(viewController: UIViewController) {
+        viewController.showCMAlert(titleText: "앱에서 사진을 업로드하려면 갤러리 접근이 필요합니다.\n설정에서 권한을 허용해주세요.", importantButtonText: "확인", commonButtonText: "취소", importantAction:  {
+            if let url = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }
+        })
+    }
+}

--- a/CatchMate/CatchMate/Utilities/Service/SocketService.swift
+++ b/CatchMate/CatchMate/Utilities/Service/SocketService.swift
@@ -152,7 +152,7 @@ final class SocketService {
                 """
             socket?.write(string: frame)
             print("✅ 채팅방 \(roomID) 구독 요청 보냄")
-            UserDefaults.standard.set(roomID, forKey: UserDefaultsKeys.chatInfo.chatRoomId)
+            UserDefaults.standard.set(roomID, forKey: UserDefaultsKeys.ChatInfo.chatRoomId)
             
         } catch {
             print("⚠️ WebSocket 상태 확인 실패: \(error)")
@@ -182,7 +182,7 @@ final class SocketService {
             socket?.write(string: frame)
             subscriptions.removeValue(forKey: roomID)
             print("🚫 채팅방 \(roomID) 구독 해제 요청 전송")
-            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.chatInfo.chatRoomId)
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.ChatInfo.chatRoomId)
 
         } catch {
             print("⚠️ WebSocket 상태 확인 실패: \(error)")

--- a/CatchMate/CatchMate/Utilities/Service/SocketService.swift
+++ b/CatchMate/CatchMate/Utilities/Service/SocketService.swift
@@ -152,6 +152,7 @@ final class SocketService {
                 """
             socket?.write(string: frame)
             print("✅ 채팅방 \(roomID) 구독 요청 보냄")
+            UserDefaults.standard.set(roomID, forKey: UserDefaultsKeys.chatInfo.chatRoomId)
             
         } catch {
             print("⚠️ WebSocket 상태 확인 실패: \(error)")
@@ -181,6 +182,7 @@ final class SocketService {
             socket?.write(string: frame)
             subscriptions.removeValue(forKey: roomID)
             print("🚫 채팅방 \(roomID) 구독 해제 요청 전송")
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.chatInfo.chatRoomId)
 
         } catch {
             print("⚠️ WebSocket 상태 확인 실패: \(error)")


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

> - 문의하기 완료 후 네비게이션 루트로 이동
> - api Service 타임아웃 적용 및 불필요한 에러케이스 제거
> - 버튼 연속요청 막기
> - 푸시알림 핸들링
> - 받은 신청 신청시간 변경, 실시간 보낸 채팅 타임존 다른 오류 수정
> - 앱버전 관리 및 강제 업데이트 서비스 추가
> - 프로필 사진 권한 설정, 이미지 수정 추가
> - 찜하기 토스트 메시지 적용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
